### PR TITLE
Added a callback prop for snapToItem

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ containerCustomStyle | Optional styles for Scrollview's global wrapper | Number 
 contentContainerCustomStyle | Optional styles for Scrollview's items container | Number | `null`
 inactiveSlideScale | Value of the 'scale' transform applied to inactive slides | Number | `0.9`
 inactiveSlideOpacity | Value of the opacity effect applied to inactive slides | Number | `1`
+onSnapToItem | Callback for snapToItem events | Function | `(item) => {console.log(item)}`
 
 ## Methods
 

--- a/index.js
+++ b/index.js
@@ -83,7 +83,11 @@ export default class Carousel extends Component {
          * Snapping on android is kinda choppy, especially
          * when swiping quickly so you can disable it
          */
-        snapOnAndroid: PropTypes.bool
+        snapOnAndroid: PropTypes.bool,
+        /**
+         * For a callback on snapToItem
+         */
+        onSnapToItem: PropTypes.func,
     };
 
     static defaultProps = {
@@ -326,6 +330,7 @@ export default class Carousel extends Component {
 
         const snapX = this._positions[index].start;
         this.refs.scrollview.scrollTo({x: snapX, y: 0, animated});
+        this.props.onSnapToItem && this.props.onSnapToItem(index);
     }
 
     render () {


### PR DESCRIPTION
Added a function prop `onSnapToItem` for getting callbacks for snapToItem events. This can be used as follows:
```JSX
<Carousel
    ref={'carousel'}
    onSnapToItem={(item) => {
        console.log(item);
    }}
    items={this.state.entries}
    renderItem={this._renderItem}
    sliderWidth={this.state.width}
    itemWidth={pageWidth}
    firstItem={1}
    showsHorizontalScrollIndicator={false}
/>
```