### PR TITLE
Implement showScrollIndicator prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ enableSnap | If enabled, releasing the touch will scroll to the center of the ne
 firstItem | Index of the first item to display | Number | `0`
 inactiveSlideOpacity | Value of the opacity effect applied to inactive slides | Number | `1`
 inactiveSlideScale | Value of the 'scale' transform applied to inactive slides | Number | `0.9`
-shouldOptimizeUpdates | whether to implement a `shouldComponentUpdate` strategy to minimize updates | Boolean | `true`
+shouldOptimizeUpdates | Whether to implement a `shouldComponentUpdate` strategy to minimize updates | Boolean | `true`
+showScrollIndicator | Whether the horizontal scroll indicator should be displayed | Boolean | `true`
 slideStyle | Optional style for each item's container (the one whose scale and opacity are animated) | Animated View Style Object | {}
 snapOnAndroid | Snapping on android is kinda choppy, especially when swiping quickly so you can disable it | Boolean | `true`
 swipeThreshold | Delta x when swiping to trigger the snap | Number | `20`

--- a/index.js
+++ b/index.js
@@ -74,10 +74,14 @@ export default class Carousel extends Component {
          */
         slideStyle: Animated.View.propTypes.style,
         /**
-         * whether to implement a `shouldComponentUpdate`
+         * Whether to implement a `shouldComponentUpdate`
          * strategy to minimize updates
          */
         shouldOptimizeUpdates: PropTypes.bool,
+        /**
+        * Whether the horizontal scroll indicator should be displayed
+        */
+        showScrollIndicator: PropTypes.bool,
         /**
          * Snapping on android is kinda choppy, especially
          * when swiping quickly so you can disable it
@@ -110,6 +114,7 @@ export default class Carousel extends Component {
         inactiveSlideScale: 0.9,
         slideStyle: {},
         shouldOptimizeUpdates: true,
+        showScrollIndicator: true,
         snapOnAndroid: true,
         swipeThreshold: 20
     }
@@ -438,7 +443,7 @@ export default class Carousel extends Component {
     }
 
     render () {
-        const { sliderWidth, itemWidth, containerCustomStyle, contentContainerCustomStyle, enableMomentum } = this.props;
+        const { sliderWidth, itemWidth, containerCustomStyle, contentContainerCustomStyle, enableMomentum, showScrollIndicator } = this.props;
 
         const containerSideMargin = (sliderWidth - itemWidth) / 2;
         const style = [
@@ -464,6 +469,7 @@ export default class Carousel extends Component {
               onScroll={this._onScroll}
               onTouchStart={this._onTouchStart}
               scrollEventThrottle={50}
+              showsHorizontalScrollIndicator={showScrollIndicator}
               {...this.props}
               >
                 { this._childSlides() }


### PR DESCRIPTION
This PR aims to add a `showScrollIndicator` prop to `<Carousel />`. Given that the library only support horizontal flow for now, this prop will only target `<ScrollView />`'s `showsHorizontalScrollIndicator ` prop.

#### BEFORE :
![before](https://cloud.githubusercontent.com/assets/8975443/23990163/7712c830-0a35-11e7-834f-2646b23280e0.gif)

#### AFTER :
<img width="300" alt="after" src="https://cloud.githubusercontent.com/assets/8975443/23990165/79736c06-0a35-11e7-9d6a-361aed4426ab.gif">
