### PR TITLE
Fix issue with _onScroll after remove a scrolled item

### DIFF
--- a/index.js
+++ b/index.js
@@ -276,7 +276,7 @@ export default class Carousel extends Component {
 
     _onScroll (event) {
         const { animationFunc, animationOptions, enableMomentum } = this.props;
-        const { activeItem } = this.state;
+        let { activeItem } = this.state;
         const newActiveItem = this._getActiveItem(this._getCenterX(event));
 
         if (enableMomentum) {
@@ -284,6 +284,8 @@ export default class Carousel extends Component {
         }
 
         if (activeItem !== newActiveItem) {
+            activeItem = this.state.interpolators[activeItem] === undefined ? activeItem - 1 : activeItem;
+
             Animated[animationFunc](
                 this.state.interpolators[activeItem],
                 { ...animationOptions, toValue: 0 }

--- a/package.json
+++ b/package.json
@@ -1,34 +1,34 @@
 {
-    "name": "react-native-snap-carousel",
-    "version": "2.1.2",
-    "description": "Swiper component for React Native with previews and snapping effect. Compatible with Android & iOS.",
-    "main": "index.js",
-    "repository": {
+  "name": "react-native-snap-carousel",
+  "version": "2.1.3",
+  "description": "Swiper component for React Native with previews and snapping effect. Compatible with Android & iOS.",
+  "main": "index.js",
+  "repository": {
     "type": "git",
-        "url": "github.com/archriss/react-native-snap-carousel"
-    },
-    "keywords": [
-        "react",
-        "native",
-        "carousel",
-        "slider",
-        "swiper",
-        "items",
-        "snap",
-        "android",
-        "ios",
-        "simple",
-        "snapping",
-        "component",
-        "rtl"
-    ],
-    "author": "Archriss",
-    "license": "ISC",
-    "dependencies": {
-        "react-addons-shallow-compare": "15.5.0"
-    },
-    "peerDependencies": {
-       "react": "*",
-        "react-native": "*"
-    }
+    "url": "github.com/archriss/react-native-snap-carousel"
+  },
+  "keywords": [
+    "react",
+    "native",
+    "carousel",
+    "slider",
+    "swiper",
+    "items",
+    "snap",
+    "android",
+    "ios",
+    "simple",
+    "snapping",
+    "component",
+    "rtl"
+  ],
+  "author": "Archriss",
+  "license": "ISC",
+  "dependencies": {
+    "react-addons-shallow-compare": "15.5.0"
+  },
+  "peerDependencies": {
+    "react": "*",
+    "react-native": "*"
+  }
 }


### PR DESCRIPTION
the Animated in _onScroll method throws an error after to remove an item that was scrolled before.
I'm using this case for my app, the user scrolls the items and remove items just clicking them.