### PR TITLE
Recalculate card positions on layout to handle rotation

### DIFF
--- a/index.js
+++ b/index.js
@@ -146,7 +146,6 @@ export default class Carousel extends Component {
             oldItemIndex: this._getFirstItem(props.firstItem)
         };
         this._positions = [];
-        this._calcCardPositions(props);
         this._onTouchStart = this._onTouchStart.bind(this);
         this._onScroll = this._onScroll.bind(this);
         this._onScrollEnd = this._snapEnabled ? this._onScrollEnd.bind(this) : false;

--- a/index.js
+++ b/index.js
@@ -552,6 +552,7 @@ export default class Carousel extends Component {
               onResponderRelease={this._onTouchRelease}
               onScroll={this._onScroll}
               onTouchStart={this._onTouchStart}
+              onLayout={this._calcCardPositions()}
             >
                 { this._childSlides() }
             </ScrollView>

--- a/index.js
+++ b/index.js
@@ -153,6 +153,7 @@ export default class Carousel extends Component {
         this._onScrollBegin = this._snapEnabled ? this._onScrollBegin.bind(this) : false;
         this._initInterpolators = this._initInterpolators.bind(this);
         this._onTouchRelease = this._onTouchRelease.bind(this);
+        this._onLayout = this._onLayout.bind(this);        
         // This bool aims at fixing an iOS bug due to scrolTo that triggers onMomentumScrollEnd.
         // onMomentumScrollEnd fires this._snapScroll, thus creating an infinite loop.
         this._ignoreNextMomentum = false;
@@ -361,6 +362,11 @@ export default class Carousel extends Component {
         }
     }
 
+    _onLayout (event) {
+        this._calcCardPositions();
+        this.snapToItem(this.state.activeItem, false, true, false);
+    }
+
     _snapScroll (deltaX) {
         const { swipeThreshold } = this.props;
 
@@ -552,7 +558,7 @@ export default class Carousel extends Component {
               onResponderRelease={this._onTouchRelease}
               onScroll={this._onScroll}
               onTouchStart={this._onTouchStart}
-              onLayout={this._calcCardPositions()}
+              onLayout={this._onLayout}
             >
                 { this._childSlides() }
             </ScrollView>


### PR DESCRIPTION
I was getting problems in my implementation when rotating the device, cards were resizing but not being positioned correctly.

I saw there was a TODO to handle the device orientation event but I found that binding `_calcCardPositions` to `onLayout` for the parent `ScrollView` seemed to work well for me.