### PR TITLE
Reverts „Animated.parallel“ due to animation bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -417,7 +417,9 @@ export default class Carousel extends Component {
                     this.state.interpolators[newActiveItem],
                     { ...animationOptions, toValue: 1 }
                 )
-            ]).start();
+            ], {
+                stopTogether: false,
+            }).start();
         }
     }
 


### PR DESCRIPTION
### Summary 

* `Animated.parallel(…)` was introduced in 42e5533.
* This leads to killed animated in case of `snapToItem` calls as you can see in the captures below

### Situation

* I manually `snapToItem` when the user "taps" on an item
* Before the usage of `Animated.parallel(…)` the animations for active and inactive slides were correctly running
* After the usage of `Animated.parallel(...)` the animation of the now inactive slide was aborted. This is shown in the second capture at "Item 32"
* I couldn't find any drawbacks in reverting to not-using `Animated.parallel`

### Without `Animated.parallel` (2.1.x)

![2 1 4](https://user-images.githubusercontent.com/678542/27125087-6da4607e-50f3-11e7-813b-bb96a622b74f.gif)

### With `Animated.parallel` (2.2.x)

![220](https://user-images.githubusercontent.com/678542/27125100-7777a8ae-50f3-11e7-8075-7ba30aaebc42.gif)