### PR TITLE
Fix _flatlist.scrollToIndex error and setState warning when unmounted

### DIFF
--- a/src/carousel/Carousel.js
+++ b/src/carousel/Carousel.js
@@ -160,7 +160,7 @@ export default class Carousel extends Component {
 
         this._initInterpolators(this.props);
 
-        setTimeout(() => {
+        this._initTimeout = setTimeout(() => {
             this.snapToItem(_firstItem, false, false, true);
 
             if (autoplay) {
@@ -169,7 +169,7 @@ export default class Carousel extends Component {
         }, 0);
 
         // hide FlatList's awful init
-        setTimeout(() => {
+        this._hideFlatListTimeout = setTimeout(() => {
             this.setState({ hideCarousel: false });
         }, apparitionDelay);
     }
@@ -243,6 +243,8 @@ export default class Carousel extends Component {
 
     componentWillUnmount () {
         this.stopAutoplay();
+        clearTimeout(this._initTimeout);
+        clearTimeout(this._hideFlatListTimeout);
         clearTimeout(this._enableAutoplayTimeout);
         clearTimeout(this._autoplayTimeout);
         clearTimeout(this._snapNoMomentumTimeout);


### PR DESCRIPTION
1) I'm not sure why there is a setTimout with zero time, this causing _flatlist.scrollToIndex error when unmounted on a certain situation where the parent component require to re-render.

2) Updating state inside setTimeout raise a warning when unmounted on a certain situation where the parent component require to re-render.