### PR TITLE
Preventing blocking touches on overlapping items

### DIFF
--- a/src/carousel/Carousel.js
+++ b/src/carousel/Carousel.js
@@ -730,7 +730,7 @@ export default class Carousel extends Component {
         } : undefined;
 
         return (
-            <Component style={[slideStyle, animatedStyle]}>
+            <Component style={[slideStyle, animatedStyle]} pointerEvents="box-none">
                 { renderItem({ item, index }, parallaxProps) }
             </Component>
         );


### PR DESCRIPTION
Added pointerEvents="box-none" to item wrapper to prevent blocking touches when items are overlapping and have touchable children.