### PR TITLE
Support for custom snap animations

### DIFF
--- a/src/carousel/Carousel.js
+++ b/src/carousel/Carousel.js
@@ -48,7 +48,10 @@ export default class Carousel extends Component {
         shouldOptimizeUpdates: PropTypes.bool,
         swipeThreshold: PropTypes.number,
         vertical: PropTypes.bool,
-        onSnapToItem: PropTypes.func
+        onSnapToItem: PropTypes.func,
+
+        customSnapAnimation: PropTypes.func,
+        scrollAnimationValue: PropTypes.object,
     };
 
     static defaultProps = {
@@ -101,6 +104,7 @@ export default class Carousel extends Component {
         this._scrollEnabled = props.scrollEnabled === false ? false : true;
 
         this._initPositionsAndInterpolators = this._initPositionsAndInterpolators.bind(this);
+        this._initCustomSnapAnimation = this._initCustomSnapAnimation.bind(this);
         this._renderItem = this._renderItem.bind(this);
         this._onSnap = this._onSnap.bind(this);
 
@@ -151,6 +155,7 @@ export default class Carousel extends Component {
         const { apparitionDelay } = this.props;
 
         this._initPositionsAndInterpolators();
+        this._initCustomSnapAnimation()
 
         if (apparitionDelay) {
             // Hide FlatList's awful init
@@ -172,7 +177,7 @@ export default class Carousel extends Component {
 
     componentWillReceiveProps (nextProps) {
         const { interpolators } = this.state;
-        const { firstItem, itemHeight, itemWidth, sliderHeight, sliderWidth } = nextProps;
+        const { firstItem, itemHeight, itemWidth, sliderHeight, sliderWidth, vertical, scrollAnimationValue, customSnapAnimation } = nextProps;
         const itemsLength = this._getCustomDataLength(nextProps);
 
         if (!itemsLength) {
@@ -492,6 +497,25 @@ export default class Carousel extends Component {
         this.setState({ interpolators });
     }
 
+    _customAnimatedListener({value}) {
+        if(this._flatlist && this._flatlist._listRef) {
+            this._flatlist.scrollToOffset({
+                offset: value,
+                animated: false
+            })
+        }
+    }
+
+    _initCustomSnapAnimation(props = this.props) {
+        const { customSnapAnimation, scrollAnimationValue } = props
+        if(!customSnapAnimation || !scrollAnimationValue) {
+            this._animatedListener = undefined
+        }
+        else {
+            this._animatedListener = scrollAnimationValue.addListener(this._customAnimatedListener.bind(this))
+        }
+    }
+
     _hackActiveSlideAnimation (index, goTo, force = false) {
         const { data } = this.props;
 
@@ -752,6 +776,18 @@ export default class Carousel extends Component {
         }
     }
 
+    _scrollToOffset(offset, animated) {
+        if(animated && this.props.customSnapAnimation) {
+            this.props.customSnapAnimation(offset)
+        }
+        else {
+            this._flatlist && this._flatlist._listRef && this._flatlist.scrollToOffset({
+                offset: offset,
+                animated
+            });
+        }
+    }
+
     _snapToItem (index, animated = true, fireCallback = true, initial = false, lockScroll = true) {
         const { enableMomentum, onSnapToItem } = this.props;
         const itemsLength = this._getCustomDataLength();
@@ -787,10 +823,7 @@ export default class Carousel extends Component {
             return;
         }
 
-        this._flatlist && this._flatlist._listRef && this._flatlist.scrollToOffset({
-            offset: this._scrollOffsetRef,
-            animated
-        });
+        this._scrollToOffset(this._scrollOffsetRef, animated)
 
         if (enableMomentum) {
             // iOS fix, check the note in the constructor

--- a/src/carousel/Carousel.js
+++ b/src/carousel/Carousel.js
@@ -155,7 +155,7 @@ export default class Carousel extends Component {
         const { apparitionDelay } = this.props;
 
         this._initPositionsAndInterpolators();
-        this._initCustomSnapAnimation()
+        this._initCustomSnapAnimation();
 
         if (apparitionDelay) {
             // Hide FlatList's awful init
@@ -177,7 +177,7 @@ export default class Carousel extends Component {
 
     componentWillReceiveProps (nextProps) {
         const { interpolators } = this.state;
-        const { firstItem, itemHeight, itemWidth, sliderHeight, sliderWidth, vertical, scrollAnimationValue, customSnapAnimation } = nextProps;
+        const { firstItem, itemHeight, itemWidth, sliderHeight, sliderWidth, vertical } = nextProps;
         const itemsLength = this._getCustomDataLength(nextProps);
 
         if (!itemsLength) {
@@ -507,12 +507,12 @@ export default class Carousel extends Component {
     }
 
     _initCustomSnapAnimation(props = this.props) {
-        const { customSnapAnimation, scrollAnimationValue } = props
+        const { customSnapAnimation, scrollAnimationValue } = props;
         if(!customSnapAnimation || !scrollAnimationValue) {
-            this._animatedListener = undefined
+            this._animatedListener = undefined;
         }
         else {
-            this._animatedListener = scrollAnimationValue.addListener(this._customAnimatedListener.bind(this))
+            this._animatedListener = scrollAnimationValue.addListener(this._customAnimatedListener.bind(this));
         }
     }
 
@@ -778,7 +778,7 @@ export default class Carousel extends Component {
 
     _scrollToOffset(offset, animated) {
         if(animated && this.props.customSnapAnimation) {
-            this.props.customSnapAnimation(offset)
+            this.props.customSnapAnimation(offset);
         }
         else {
             this._flatlist && this._flatlist._listRef && this._flatlist.scrollToOffset({


### PR DESCRIPTION
I'm sure that this isn't going to be accepted as-is, but I figured I would at least start a discussion on it.

I have an app which is using the react-native-snap-carousel, but all snaps are done on button presses and not through scrolling to the next item. I wanted to do a custom animation when scrolling to the next element after the press.

Using the strategy described in this SO post, I'm able to animate the scroll position using whatever Animated effect I want. (https://stackoverflow.com/questions/43881186/how-can-i-animate-scroll-in-react-native).

This commit is working for my own needs, but I'm sure it would need additional changes to support manual scrolling as well. (Need to updated the scrollAnimationValue whenever the user scrolls by hand.)

An example of usage would be:

      this.animatedScrollValue = new Animated.Value(0)

      <Carousel
        ...
        scrollAnimationValue={this.animatedScrollValue}
        customSnapAnimation={(offset) => {
          Animated.timing(this.animatedScrollValue, {
            toValue: offset,
            duration: 1000,
            easing: Easing.out(Easing.cubic)
          }).start();
        }}
        />