### PR TITLE
Support keyExtractor on ScrollView

### DIFF
--- a/src/carousel/Carousel.js
+++ b/src/carousel/Carousel.js
@@ -1113,9 +1113,9 @@ export default class Carousel extends Component {
             itemHeight
         } : undefined;
 
-        const specificProps = {
+        const specificProps = this._needsScrollView() ? {
             key: keyExtractor ? keyExtractor(item, index) : this._getKeyExtractor(item, index),
-        };
+        } : {};
 
         return (
             <Component style={[slideStyle, animatedStyle]} pointerEvents={'box-none'} {...specificProps}>

--- a/src/carousel/Carousel.js
+++ b/src/carousel/Carousel.js
@@ -134,6 +134,8 @@ export default class Carousel extends Component {
         this._onTouchStart = this._onTouchStart.bind(this);
         this._onTouchRelease = this._onTouchRelease.bind(this);
 
+        this._getKeyExtractor = this._getKeyExtractor.bind(this);
+
         // Native driver for scroll events
         const scrollEventConfig = {
             listener: this._onScroll,
@@ -456,7 +458,7 @@ export default class Carousel extends Component {
     }
 
     _getKeyExtractor (item, index) {
-        return `flatlist-item-${index}`;
+        return this._needsScrollView() ? `scrollview-item-${index}` : `flatlist-item-${index}`;
     }
 
     _getScrollOffset (event) {
@@ -1083,6 +1085,7 @@ export default class Carousel extends Component {
             hasParallaxImages,
             itemWidth,
             itemHeight,
+            keyExtractor,
             renderItem,
             sliderHeight,
             sliderWidth,
@@ -1110,9 +1113,9 @@ export default class Carousel extends Component {
             itemHeight
         } : undefined;
 
-        const specificProps = this._needsScrollView() ? {
-            key: `scrollview-item-${index}`
-        } : {};
+        const specificProps = {
+            key: keyExtractor ? keyExtractor(item, index) : this._getKeyExtractor(item, index),
+        };
 
         return (
             <Component style={[slideStyle, animatedStyle]} pointerEvents={'box-none'} {...specificProps}>


### PR DESCRIPTION
All child elements with ScrollView is given key `scrollview-item-{$index}`. 
When the source data elements index positions change, due to sort / pop; the rendered item gets re-created. This patch enables keyExtractor prop to apply keys for ScrollView as well.