### PR TITLE
Allow changing scrollEnabled to true from initially false

### DIFF
--- a/src/carousel/Carousel.js
+++ b/src/carousel/Carousel.js
@@ -214,7 +214,7 @@ export default class Carousel extends Component {
 
     componentWillReceiveProps (nextProps) {
         const { interpolators } = this.state;
-        const { firstItem, itemHeight, itemWidth, sliderHeight, sliderWidth } = nextProps;
+        const { firstItem, itemHeight, itemWidth, scrollEnabled, sliderHeight, sliderWidth } = nextProps;
         const itemsLength = this._getCustomDataLength(nextProps);
 
         if (!itemsLength) {
@@ -228,10 +228,16 @@ export default class Carousel extends Component {
         const hasNewSliderHeight = sliderHeight && sliderHeight !== this.props.sliderHeight;
         const hasNewItemWidth = itemWidth && itemWidth !== this.props.itemWidth;
         const hasNewItemHeight = itemHeight && itemHeight !== this.props.itemHeight;
+        const hasNewScrollEnabled = scrollEnabled !== this.props.scrollEnabled;
 
         // Prevent issues with dynamically removed items
         if (nextActiveItem > itemsLength - 1) {
             nextActiveItem = itemsLength - 1;
+        }
+
+        // Handle changing scrollEnabled independent of user -> carousel interaction
+        if (hasNewScrollEnabled) {
+          this._setScrollEnabled(scrollEnabled);
         }
 
         if (interpolators.length !== itemsLength || hasNewSliderWidth ||
@@ -447,7 +453,7 @@ export default class Carousel extends Component {
     _setScrollEnabled (value = true) {
         const { scrollEnabled } = this.props;
 
-        if (scrollEnabled === false || !this._scrollComponent || !this._scrollComponent.setNativeProps) {
+        if (!this._scrollComponent || !this._scrollComponent.setNativeProps) {
             return;
         }
 


### PR DESCRIPTION
We have a use case where a carousel is the second page of a `pagingEnabled={true}` scrollview. I know that nesting is frowned upon, but we've gotten it to mostly work. We set the carousel's `scrollEnabled` to `true`, and the outer's to `false`, when the outer scrollview hits the second page. 

However, we noticed the first card required scrolling all the way to the next page before we could easily swipe between cards:

![before](https://user-images.githubusercontent.com/1112872/37047074-efd4a436-2137-11e8-9ffa-8d7dc9e6fe92.gif)

If we allow changing scrollEnabled to true in `componentWillReceiveProps`, we can accept a `scrollEnabled` change before any user interaction:

![after](https://user-images.githubusercontent.com/1112872/37047117-06e554f4-2138-11e8-84ec-406a07773f39.gif)

This might also address some issues referencing the scroll "bouncing back" to the first card.