### PR TITLE
add useNativeDriver property to support RN 35

### DIFF
--- a/src/carousel/Carousel.js
+++ b/src/carousel/Carousel.js
@@ -66,7 +66,8 @@ export default class Carousel extends Component {
         useScrollView: PropTypes.bool,
         vertical: PropTypes.bool,
         onBeforeSnapToItem: PropTypes.func,
-        onSnapToItem: PropTypes.func
+        onSnapToItem: PropTypes.func,
+        useNativeDriver: PropTypes.bool
     };
 
     static defaultProps = {
@@ -97,7 +98,8 @@ export default class Carousel extends Component {
         shouldOptimizeUpdates: true,
         swipeThreshold: 20,
         useScrollView: !AnimatedFlatList,
-        vertical: false
+        vertical: false,
+        useNativeDriver: true,
     }
 
     constructor (props) {
@@ -144,7 +146,7 @@ export default class Carousel extends Component {
         // Native driver for scroll events
         const scrollEventConfig = {
             listener: this._onScroll,
-            useNativeDriver: true
+            useNativeDriver: this.props.useNativeDriver,
         };
         this._scrollPos = new Animated.Value(0);
         this._onScrollHandler = props.vertical ?
@@ -605,7 +607,7 @@ export default class Carousel extends Component {
 
         const animationCommonOptions = {
             isInteraction: false,
-            useNativeDriver: true,
+            useNativeDriver: this.props.useNativeDriver,
             ...activeAnimationOptions,
             toValue: toValue
         };


### PR DESCRIPTION
React Native is not supporting animations with `useNativeDriver: true` property, so I made it configurable.

Here is a closed issue which is caused by the same issue (actually I got the same error):
https://github.com/archriss/react-native-snap-carousel/issues/289