### PR TITLE
fix(carousel): Animated.View.propTypes will cause crash in release mode

### DIFF
--- a/src/carousel/Carousel.js
+++ b/src/carousel/Carousel.js
@@ -60,7 +60,7 @@ export default class Carousel extends Component {
         loopClonesPerSide: PropTypes.number,
         scrollInterpolator: PropTypes.func,
         slideInterpolatedStyle: PropTypes.func,
-        slideStyle: Animated.View.propTypes.style,
+        slideStyle: ViewPropTypes ? ViewPropTypes.style : View.propTypes.style,
         shouldOptimizeUpdates: PropTypes.bool,
         swipeThreshold: PropTypes.number,
         useScrollView: PropTypes.bool,


### PR DESCRIPTION
reference:
https://github.com/facebook/react-native/issues/16920
https://github.com/facebook/react-native/issues/16542