### PR TITLE
Fix ParallaxImage not being rendered

### DIFF
--- a/src/parallaximage/ParallaxImage.js
+++ b/src/parallaximage/ParallaxImage.js
@@ -46,6 +46,7 @@ export default class ParallaxImage extends Component {
         };
         this._onLoad = this._onLoad.bind(this);
         this._onError = this._onError.bind(this);
+        this._measureLayout = this._measureLayout.bind(this);
     }
 
     setNativeProps (nativeProps) {


### PR DESCRIPTION
This is probably linked to issue #310 and maybe #185.

My issue was that sometimes the ParallaxImage wasn't displayed, I got stuck with the loader.

I realised that when `_measureLayout` is called as the callback of the `onLayout` prop of the `View`, `this` is not the `ParallaxImage` but the global scope.
Therefore `this._container` is not defined and the image's dynamic style props are not updated.

This seems to fix the issue permanently.