### PR TITLE
Docs: Fix non-permanent GitHub link

### DIFF
--- a/doc/TIPS_AND_TRICKS.md
+++ b/doc/TIPS_AND_TRICKS.md
@@ -95,7 +95,7 @@ const styles = Stylesheet.create({
 
 ## Carousel's stretched height
 
-Since `<Carousel />` is, ultimately, based on `<ScrollView />`, it inherits [its default styles](https://github.com/facebook/react-native/blob/master/Libraries/Components/ScrollView/ScrollView.js#L864) and particularly `{ flexGrow: 1 }`. This means that, by default, **the carousel container will stretch to fill up all available space**.
+Since `<Carousel />` is, ultimately, based on `<ScrollView />`, it inherits [its default styles](https://github.com/facebook/react-native/blob/9c1ea45d38a6ec731894443debe8879fa3876ab7/Libraries/Components/ScrollView/ScrollView.js#L879-L881) and particularly `{ flexGrow: 1 }`. This means that, by default, **the carousel container will stretch to fill up all available space**.
 
 If this is not what you're after, you can prevent this behavior by passing `{ flexGrow: 0 }` to prop `containerCustomStyle`.
 


### PR DESCRIPTION
### Platforms affected
N/A

### What does this PR do?
Link was pointing to master version from react-native docs. This produces broken links with each new react-native version.
Also added multiline link to cover all ScrollView default styles.

### What testing has been done on this change?
Check that new link points to the right docs.

### Tested features checklist
N/A