### PR TITLE
Stylesheet should use CamelCase

### DIFF
--- a/doc/TIPS_AND_TRICKS.md
+++ b/doc/TIPS_AND_TRICKS.md
@@ -59,7 +59,7 @@ const sliderWidth = Dimensions.get('window').width;
 const itemWidth = slideWidth + horizontalMargin * 2;
 const itemHeight = 200;
 
-const styles = Stylesheet.create({
+const styles = StyleSheet.create({
     slide: {
         width: itemWidth,
         height: itemHeight,


### PR DESCRIPTION
**Platforms affected**
iOS & Android

**What does this PR do?**
Fix a typo in the code. "Stylesheet" should be "StyleSheet" in order to use the right react-native package.

**What testing has been done on this change?**
Tested on both platforms and it removed the error screen.

**Tested features checklist**

- [x]   Default setup (example)
- [ ]   Carousels with and without momentum enabled (prop enableMomentum)
- [ ]   Vertical carousels (prop vertical)
- [ ]   Slide alignment (prop activeSlideAlignment)
- [ ]   Autoplay (prop autoplay)
- [ ]   Loop mode (prop loop)
- [ ]   ScrollView/FlatList carousels (prop useScrollView)
- [ ]   Callback methods
- [ ]   ParallaxImage component
- [ ]   Pagination component
- [ ]   Layouts and custom interpolations