### PR TITLE
Fixed incorrect snap issue after scrollEnabled was changed.

### DIFF
--- a/src/carousel/Carousel.js
+++ b/src/carousel/Carousel.js
@@ -310,8 +310,8 @@ export default class Carousel extends Component {
     }
 
     _canLockScroll () {
-        const { enableMomentum, lockScrollWhileSnapping } = this.props;
-        return !enableMomentum && lockScrollWhileSnapping;
+        const { scrollEnabled, enableMomentum, lockScrollWhileSnapping } = this.props;
+        return scrollEnabled && !enableMomentum && lockScrollWhileSnapping;
     }
 
     _enableLoop () {
@@ -468,19 +468,17 @@ export default class Carousel extends Component {
         return this._scrollEnabled;
     }
 
-    _setScrollEnabled (value = true) {
-        const { scrollEnabled } = this.props;
+    _setScrollEnabled (scrollEnabled = true) {
         const wrappedRef = this._getWrappedRef();
 
         if (!wrappedRef || !wrappedRef.setNativeProps) {
             return;
         }
 
-        value = value && scrollEnabled
         // 'setNativeProps()' is used instead of 'setState()' because the latter
         // really takes a toll on Android behavior when momentum is disabled
-        wrappedRef.setNativeProps({ scrollEnabled: value });
-        this._scrollEnabled = value;
+        wrappedRef.setNativeProps({ scrollEnabled });
+        this._scrollEnabled = scrollEnabled;
     }
 
     _getKeyExtractor (item, index) {


### PR DESCRIPTION
### Platforms affected
All

### What does this PR do?
Snap is not working correctly after `scrollEnabled` was changed repeatedly.
I guess this is because of the previous PR (#390).

-----

Step 1. Set scrollEnabled={true}
Step 2. Set scrollEnabled={false}
Step 3. Set scrollEnabled={true}
Step 4. Snap is not working correctly.

[Here](https://github.com/archriss/react-native-snap-carousel/blob/v3.7.4/src/carousel/Carousel.js#L479) is where the problem occurs. In Step 3, this._setScrollEnabled(true) is called.

```js
value = value && this.props.scrollEnabled; // value = true && false; value is false
```

I tried to make the related logic work a little more efficiently. I hope this helps.

### What testing has been done on this change?
After applying this patch, You can see if the above steps reproduce the problem I pointed out.

### Tested features checklist
<!--
IMPORTANT: Please make sure that none of these features have been broken by your changes.
It's easy to overlook something you didn't use yet.
-->
- [X] Default setup ([example](https://github.com/archriss/react-native-snap-carousel/blob/master/example/src/index.js#L46-L87))
- [X] Carousels with and without momentum enabled ([prop `enableMomentum`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#behavior))
- [X] Vertical carousels ([prop `vertical`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#behavior))
- [X] Slide alignment ([prop `activeSlideAlignment`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#style-and-animation))
- [X] Autoplay ([prop `autoplay`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#autoplay))
- [X] Loop mode ([prop `loop`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#loop))
- [X] `ScrollView`/`FlatList` carousels ([prop `useScrollView`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#behavior))
- [X] [Callback methods](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#callbacks)
- [X] [`ParallaxImage` component](https://github.com/archriss/react-native-snap-carousel#parallaximage-component)
- [X] [`Pagination` component](https://github.com/archriss/react-native-snap-carousel#pagination-component)
- [X] [Layouts and custom interpolations](https://github.com/archriss/react-native-snap-carousel#layouts-and-custom-interpolations)
