### PR TITLE
Not call onScroll when momentum is enabled and just changed dimensions

### DIFF
--- a/src/carousel/Carousel.js
+++ b/src/carousel/Carousel.js
@@ -266,7 +266,7 @@ export default class Carousel extends Component {
             }
 
             if (hasNewSliderWidth || hasNewSliderHeight || hasNewItemWidth || hasNewItemHeight) {
-                this._snapToItem(nextActiveItem, false, false, false, false);
+                this._snapToItem(nextActiveItem, false, false, false, false, false);
             }
         } else if (nextFirstItem !== this._previousFirstItem && nextFirstItem !== this._activeItem) {
             this._activeItem = nextFirstItem;
@@ -951,7 +951,7 @@ export default class Carousel extends Component {
         }
     }
 
-    _snapToItem (index, animated = true, fireCallback = true, initial = false, lockScroll = true) {
+    _snapToItem (index, animated = true, fireCallback = true, initial = false, lockScroll = true, enableWorkaround = true) {
         const { enableMomentum, onSnapToItem, onBeforeSnapToItem } = this.props;
         const itemsLength = this._getCustomDataLength();
         const wrappedRef = this._getWrappedRef();
@@ -1001,6 +1001,7 @@ export default class Carousel extends Component {
                 this._ignoreNextMomentum = true;
             }
 
+            if (!enableWorkaround) return;
             // When momentum is enabled and the user is overscrolling or swiping very quickly,
             // 'onScroll' is not going to be triggered for edge items. Then callback won't be
             // fired and loop won't work since the scrollview is not going to be repositioned.


### PR DESCRIPTION
### Platforms affected
Android

### What does this PR do?
It fixes a bug that occurs when updating the carousel dimensions.
At componentWillReceiveProps there is a call to the _snapToItem method:
```
if (hasNewSliderWidth || hasNewSliderHeight || hasNewItemWidth || hasNewItemHeight) {
  this._snapToItem(nextActiveItem, false, false, false, false);
}
```

And in this method we can see an workaround that calls onScroll
when was scrolled to the first or last item, but when we just change the slider or item dimensions
It will call onScroll and back to the previous index if the current item is the last item.
```
// When momentum is enabled and the user is overscrolling or swiping very quickly,
// 'onScroll' is not going to be triggered for edge items. Then callback won't be
// fired and loop won't work since the scrollview is not going to be repositioned.
// As a workaround, '_onScroll()' will be called manually for these items if a given
// condition hasn't been met after a small delay.
// WARNING: this is ok only when relying on 'momentumScrollEnd', not with 'scrollEndDrag'
if (index === 0 || index === itemsLength - 1) {
  clearTimeout(this._edgeItemTimeout);
  this._edgeItemTimeout = setTimeout(() => {
    if (!initial && index === this._activeItem && !this._onScrollTriggered) {
      this._onScroll();
    }
  }, 250);
}
```

### What testing has been done on this change?
I have only simulate this in real devices on Android and iOS, without any testing code.
