### PR TITLE
feat: fire the onTouchStart prop

### DIFF
--- a/src/carousel/Carousel.js
+++ b/src/carousel/Carousel.js
@@ -810,9 +810,13 @@ export default class Carousel extends Component {
     }
 
     _onTouchStart () {
+        const { onTouchStart } = this.props
         // `onTouchStart` is fired even when `scrollEnabled` is set to `false`
         if (this._getScrollEnabled() !== false && this._autoplaying) {
             this.stopAutoplay();
+        }
+        if (onTouchStart) {
+            onTouchStart()
         }
     }
 


### PR DESCRIPTION

### Platforms affected

all

### What does this PR do?

fire the onTouchStart prop in carousel

the onTouchStart prop didn't fire in the previous code, which may end in unwanted result.

an online demo here: https://snack.expo.io/@sanglewang/react-native-snap-carousel-demo

in the case, we have two nested vertical scrollview, on android only the outside scroll view can be scrolled. we add a state to control the scrollEnabled prop to hack it. since the onTouchStart prop did not fire in the carousel, the state will never turn to false, and the carousel cannot mannully scroll.

I was wondering why the other event props (onScrollEndDrag, onMomentumScrollEnd etc. ) are fired in the component and the onTouchStart is not. Is there any protential problem i ignored ?

### What testing has been done on this change?


### Tested features checklist
<!--
IMPORTANT: Please make sure that none of these features have been broken by your changes.
It's easy to overlook something you didn't use yet.
-->
- [x] Default setup ([example](https://github.com/archriss/react-native-snap-carousel/blob/master/example/src/index.js#L46-L87))
- [x] Carousels with and without momentum enabled ([prop `enableMomentum`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#behavior))
- [x] Vertical carousels ([prop `vertical`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#behavior))
- [x] Slide alignment ([prop `activeSlideAlignment`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#style-and-animation))
- [x] Autoplay ([prop `autoplay`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#autoplay))
- [x] Loop mode ([prop `loop`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#loop))
- [x] `ScrollView`/`FlatList` carousels ([prop `useScrollView`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#behavior))
- [x] [Callback methods](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#callbacks)
- [x] [`ParallaxImage` component](https://github.com/archriss/react-native-snap-carousel#parallaximage-component)
- [x] [`Pagination` component](https://github.com/archriss/react-native-snap-carousel#pagination-component)
- [x] [Layouts and custom interpolations](https://github.com/archriss/react-native-snap-carousel#layouts-and-custom-interpolations)
