### PR TITLE
Allow contentContainerCustomStyle override default paddings.

### DIFF
--- a/src/carousel/Carousel.js
+++ b/src/carousel/Carousel.js
@@ -1245,14 +1245,14 @@ export default class Carousel extends Component {
                 { width: sliderWidth, flexDirection: this._needsRTLAdaptations() ? 'row-reverse' : 'row' }
         ];
         const contentContainerStyle = [
-            contentContainerCustomStyle || {},
             vertical ? {
                 paddingTop: this._getContainerInnerMargin(),
                 paddingBottom: this._getContainerInnerMargin(true)
             } : {
                 paddingLeft: this._getContainerInnerMargin(),
                 paddingRight: this._getContainerInnerMargin(true)
-            }
+            },
+            contentContainerCustomStyle || {}
         ];
 
         const specificProps = !this._needsScrollView() ? {


### PR DESCRIPTION
### Platforms affected
iOS, Android

### What does this PR do?
It allows the `contentContainerCustomStyle` prop override the default paddings. The default paddings do not always work nicely with all designs.
The change itself is pretty trivial.


### What testing has been done on this change?
Tested on Android And iOS for a simple use-case
```js
<Carousel
  ...
  contentContainerCustomStyle={{ backgroundColor: 'red', paddingLeft: 10, paddingRight: 0 }}
/>
```

### Tested features checklist
<!--
IMPORTANT: Please make sure that none of these features have been broken by your changes.
It's easy to overlook something you didn't use yet.
-->
- [ ] Default setup ([example](https://github.com/archriss/react-native-snap-carousel/blob/master/example/src/index.js#L46-L87))
- [ ] Carousels with and without momentum enabled ([prop `enableMomentum`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#behavior))
- [ ] Vertical carousels ([prop `vertical`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#behavior))
- [ ] Slide alignment ([prop `activeSlideAlignment`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#style-and-animation))
- [ ] Autoplay ([prop `autoplay`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#autoplay))
- [ ] Loop mode ([prop `loop`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#loop))
- [ ] `ScrollView`/`FlatList` carousels ([prop `useScrollView`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#behavior))
- [ ] [Callback methods](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#callbacks)
- [ ] [`ParallaxImage` component](https://github.com/archriss/react-native-snap-carousel#parallaximage-component)
- [ ] [`Pagination` component](https://github.com/archriss/react-native-snap-carousel#pagination-component)
- [ ] [Layouts and custom interpolations](https://github.com/archriss/react-native-snap-carousel#layouts-and-custom-interpolations)
