### PR TITLE
Custom Scroll Component

### DIFF
--- a/src/carousel/Carousel.js
+++ b/src/carousel/Carousel.js
@@ -1284,7 +1284,7 @@ export default class Carousel extends Component {
     }
 
     render () {
-        const { data, renderItem } = this.props;
+        const { data, renderItem, useScrollView } = this.props;
 
         if (!data || !renderItem) {
             return false;
@@ -1296,14 +1296,16 @@ export default class Carousel extends Component {
             ...this._getComponentStaticProps()
         };
 
+        const ScrollViewComponent = typeof useScrollView === 'function' ? useScrollView : AnimatedScrollView
+
         return this._needsScrollView() ? (
-            <AnimatedScrollView {...props}>
+            <ScrollViewComponent {...props}>
                 {
                     this._getCustomData().map((item, index) => {
                         return this._renderItem({ item, index });
                     })
                 }
-            </AnimatedScrollView>
+            </ScrollViewComponent>
         ) : (
             <AnimatedFlatList {...props} />
         );

--- a/src/carousel/Carousel.js
+++ b/src/carousel/Carousel.js
@@ -16,7 +16,6 @@ const IS_IOS = Platform.OS === 'ios';
 
 // Native driver for scroll events
 // See: https://facebook.github.io/react-native/blog/2017/02/14/using-native-driver-for-animated.html
-const AnimatedFlatList = FlatList ? Animated.createAnimatedComponent(FlatList) : null;
 const AnimatedScrollView = Animated.createAnimatedComponent(ScrollView);
 
 // React Native automatically handles RTL layouts; unfortunately, it's buggy with horizontal ScrollView
@@ -64,6 +63,7 @@ export default class Carousel extends Component {
         slideStyle: ViewPropTypes ? ViewPropTypes.style : View.propTypes.style,
         shouldOptimizeUpdates: PropTypes.bool,
         swipeThreshold: PropTypes.number,
+        renderScrollComponent: PropTypes.func,
         useScrollView: PropTypes.bool,
         vertical: PropTypes.bool,
         onBeforeSnapToItem: PropTypes.func,
@@ -98,7 +98,8 @@ export default class Carousel extends Component {
         slideStyle: {},
         shouldOptimizeUpdates: true,
         swipeThreshold: 20,
-        useScrollView: !AnimatedFlatList,
+        renderScrollComponent: AnimatedScrollView,
+        useScrollView: !FlatList,
         vertical: false
     }
 
@@ -301,7 +302,7 @@ export default class Carousel extends Component {
 
     _needsScrollView () {
         const { useScrollView } = this.props;
-        return useScrollView || !AnimatedFlatList || this._shouldUseStackLayout() || this._shouldUseTinderLayout();
+        return useScrollView || !FlatList || this._shouldUseStackLayout() || this._shouldUseTinderLayout();
     }
 
     _needsRTLAdaptations () {
@@ -1284,7 +1285,7 @@ export default class Carousel extends Component {
     }
 
     render () {
-        const { data, renderItem } = this.props;
+        const { data, renderItem, renderScrollComponent = ScrollComponent } = this.props;
 
         if (!data || !renderItem) {
             return false;
@@ -1297,15 +1298,15 @@ export default class Carousel extends Component {
         };
 
         return this._needsScrollView() ? (
-            <AnimatedScrollView {...props}>
+            <ScrollComponent {...props}>
                 {
                     this._getCustomData().map((item, index) => {
                         return this._renderItem({ item, index });
                     })
                 }
-            </AnimatedScrollView>
+            </ScrollComponent>
         ) : (
-            <AnimatedFlatList {...props} />
+            <FlatList {...props} />
         );
     }
 }

--- a/src/carousel/Carousel.js
+++ b/src/carousel/Carousel.js
@@ -64,7 +64,7 @@ export default class Carousel extends Component {
         slideStyle: ViewPropTypes ? ViewPropTypes.style : View.propTypes.style,
         shouldOptimizeUpdates: PropTypes.bool,
         swipeThreshold: PropTypes.number,
-        useScrollView: PropTypes.bool,
+        useScrollView: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
         vertical: PropTypes.bool,
         onBeforeSnapToItem: PropTypes.func,
         onSnapToItem: PropTypes.func

--- a/src/carousel/Carousel.js
+++ b/src/carousel/Carousel.js
@@ -16,6 +16,7 @@ const IS_IOS = Platform.OS === 'ios';
 
 // Native driver for scroll events
 // See: https://facebook.github.io/react-native/blog/2017/02/14/using-native-driver-for-animated.html
+const AnimatedFlatList = FlatList ? Animated.createAnimatedComponent(FlatList) : null;
 const AnimatedScrollView = Animated.createAnimatedComponent(ScrollView);
 
 // React Native automatically handles RTL layouts; unfortunately, it's buggy with horizontal ScrollView
@@ -63,7 +64,6 @@ export default class Carousel extends Component {
         slideStyle: ViewPropTypes ? ViewPropTypes.style : View.propTypes.style,
         shouldOptimizeUpdates: PropTypes.bool,
         swipeThreshold: PropTypes.number,
-        renderScrollComponent: PropTypes.func,
         useScrollView: PropTypes.bool,
         vertical: PropTypes.bool,
         onBeforeSnapToItem: PropTypes.func,
@@ -98,8 +98,7 @@ export default class Carousel extends Component {
         slideStyle: {},
         shouldOptimizeUpdates: true,
         swipeThreshold: 20,
-        renderScrollComponent: AnimatedScrollView,
-        useScrollView: !FlatList,
+        useScrollView: !AnimatedFlatList,
         vertical: false
     }
 
@@ -302,7 +301,7 @@ export default class Carousel extends Component {
 
     _needsScrollView () {
         const { useScrollView } = this.props;
-        return useScrollView || !FlatList || this._shouldUseStackLayout() || this._shouldUseTinderLayout();
+        return useScrollView || !AnimatedFlatList || this._shouldUseStackLayout() || this._shouldUseTinderLayout();
     }
 
     _needsRTLAdaptations () {
@@ -1285,7 +1284,7 @@ export default class Carousel extends Component {
     }
 
     render () {
-        const { data, renderItem, renderScrollComponent = ScrollComponent } = this.props;
+        const { data, renderItem } = this.props;
 
         if (!data || !renderItem) {
             return false;
@@ -1298,15 +1297,15 @@ export default class Carousel extends Component {
         };
 
         return this._needsScrollView() ? (
-            <ScrollComponent {...props}>
+            <AnimatedScrollView {...props}>
                 {
                     this._getCustomData().map((item, index) => {
                         return this._renderItem({ item, index });
                     })
                 }
-            </ScrollComponent>
+            </AnimatedScrollView>
         ) : (
-            <FlatList {...props} />
+            <AnimatedFlatList {...props} />
         );
     }
 }


### PR DESCRIPTION
### Platforms affected
iOS & Android

### What does this PR do?
User can provide custom scroll component with `useScrollView` prop.

### What testing has been done on this change?
If previous layouts (layout, stack or tinder) are still working with `useScrollView` of values: `false`, `true` or custom component. 

### Example

```jsx
import { ScrollView } from 'react-native-gesture-handler'

const AnimatedScrollView = Animated.createAnimatedComponent(ScrollView);

// render
        <Carousel
          useScrollView={AnimatedScrollView}
          renderItem={this.renderItem}
          itemWidth={250}
          sliderWidth={windowWidth}
          data={data}
          {...props}
        />

```
#### why useScrollView
I choose to use the already existing prop `useScrollView` because I think it suits well the feature needed and it's pretty transparent of what this prop can do.

Previously, I wanted to use the same props as FlatList `renderScrollComponent` but I encounter conflicts between the way that ScrollView & FlatList are handled in the code logic.
Use a different prop is the best way to handle this case.

ref: https://github.com/archriss/react-native-snap-carousel/issues/466#issuecomment-477166520