### PR TITLE
V2.4.1 retrocompatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-snap-carousel",
-    "version": "2.4.0",
+    "version": "2.4.1",
     "description": "Swiper component for React Native with previews and snapping effect. Compatible with Android & iOS.",
     "main": "src/index.js",
     "repository": {

--- a/src/carousel/Carousel.js
+++ b/src/carousel/Carousel.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { ScrollView, Animated, Platform, Easing, I18nManager, ViewPropTypes } from 'react-native';
+import { View, ScrollView, Animated, Platform, Easing, I18nManager, ViewPropTypes } from 'react-native';
 import PropTypes from 'prop-types';
 import shallowCompare from 'react-addons-shallow-compare';
 import _debounce from 'lodash.debounce';
@@ -78,11 +78,11 @@ export default class Carousel extends Component {
         /**
         * Global wrapper's style
         */
-        containerCustomStyle: ViewPropTypes.style,
+        containerCustomStyle: ViewPropTypes ? ViewPropTypes.style : View.propTypes.style,
         /**
         * Content container's style
         */
-        contentContainerCustomStyle: ViewPropTypes.style,
+        contentContainerCustomStyle: ViewPropTypes ? ViewPropTypes.style : View.propTypes.style,
         /**
         * If enabled, snapping will be triggered once
         * the ScrollView stops moving, not when the

--- a/src/pagination/Pagination.js
+++ b/src/pagination/Pagination.js
@@ -9,8 +9,8 @@ export default class Pagination extends Component {
     static propTypes = {
         dotsLength: PropTypes.number.isRequired,
         activeDotIndex: PropTypes.number.isRequired,
-        containerStyle: ViewPropTypes.style,
-        dotStyle: ViewPropTypes.style,
+        containerStyle: ViewPropTypes ? ViewPropTypes.style : View.propTypes.style,
+        dotStyle: ViewPropTypes ? ViewPropTypes.style : View.propTypes.style,
         inactiveDotOpacity: PropTypes.number,
         inactiveDotScale: PropTypes.number
     };

--- a/src/pagination/PaginationDot.js
+++ b/src/pagination/PaginationDot.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Animated, Easing, ViewPropTypes } from 'react-native';
+import { Animated, Easing, View, ViewPropTypes } from 'react-native';
 import PropTypes from 'prop-types';
 import styles from './Pagination.style';
 
@@ -7,7 +7,7 @@ export default class PaginationDot extends Component {
 
     static propTypes = {
         active: PropTypes.bool,
-        style: ViewPropTypes.style,
+        style: ViewPropTypes ? ViewPropTypes.style : View.propTypes.style,
         inactiveOpacity: PropTypes.number,
         inactiveScale: PropTypes.number
     };


### PR DESCRIPTION
### Platforms affected


### What does this PR do?


### What testing has been done on this change?


### Tested features checklist
<!--
IMPORTANT: Please make sure that none of these features have been broken by your changes.
It's easy to overlook something you didn't use yet.
-->
- [x] Default setup ([example](https://github.com/archriss/react-native-snap-carousel/blob/master/example/src/index.js#L46-L87))
- [x] Carousels with and without momentum enabled ([prop `enableMomentum`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#behavior))
- [x] Vertical carousels ([prop `vertical`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#behavior))
- [x] Slide alignment ([prop `activeSlideAlignment`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#style-and-animation))
- [x] Autoplay ([prop `autoplay`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#autoplay))
- [x] Loop mode ([prop `loop`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#loop))
- [x] `ScrollView`/`FlatList` carousels ([prop `useScrollView`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#behavior))
- [x] [Callback methods](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#callbacks)
- [x] [`ParallaxImage` component](https://github.com/archriss/react-native-snap-carousel#parallaximage-component)
- [x] [`Pagination` component](https://github.com/archriss/react-native-snap-carousel#pagination-component)
- [x] [Layouts and custom interpolations](https://github.com/archriss/react-native-snap-carousel#layouts-and-custom-interpolations)
