### PR TITLE
remove override to flatlist built in functionality needed for initial item rendering bug

### DIFF
--- a/src/carousel/Carousel.js
+++ b/src/carousel/Carousel.js
@@ -1298,8 +1298,6 @@ export default class Carousel extends Component {
             // extraData: this.state,
             renderItem: this._renderItem,
             numColumns: 1,
-            getItemLayout: undefined, // see #193
-            initialScrollIndex: undefined, // see #193
             keyExtractor: keyExtractor || this._getKeyExtractor
         } : {};
 


### PR DESCRIPTION
This is referring to issues related to firstItem rendering not working reliably. (#538, #193 )
By using `getItemLayout` & `initialScrollIndex`, I am able to pass the relevant values to `FlatList` and resolve the wrong `firstItem` being rendered without having to `useScrollView` or set `initialNumToRender={data.length}`.

make sure to understand how to use both properties together:
https://facebook.github.io/react-native/docs/flatlist#initialscrollindex
https://facebook.github.io/react-native/docs/flatlist#getitemlayout