### PR TITLE
snapToItem does not work on Android with momentumEnabled

### DIFF
--- a/src/carousel/Carousel.js
+++ b/src/carousel/Carousel.js
@@ -102,7 +102,7 @@ export default class Carousel extends Component {
         vertical: false
     }
 
-    constructor(props) {
+    constructor (props) {
         super(props);
 
         this.state = {
@@ -171,7 +171,7 @@ export default class Carousel extends Component {
         }
     }
 
-    componentDidMount() {
+    componentDidMount () {
         const { apparitionDelay, autoplay, firstItem } = this.props;
         const _firstItem = this._getFirstItem(firstItem);
         const apparitionCallback = () => {
@@ -203,7 +203,7 @@ export default class Carousel extends Component {
         });
     }
 
-    shouldComponentUpdate(nextProps, nextState) {
+    shouldComponentUpdate (nextProps, nextState) {
         if (this.props.shouldOptimizeUpdates === false) {
             return true;
         } else {
@@ -211,7 +211,7 @@ export default class Carousel extends Component {
         }
     }
 
-    componentWillReceiveProps(nextProps) {
+    componentWillReceiveProps (nextProps) {
         const { interpolators } = this.state;
         const { firstItem, itemHeight, itemWidth, scrollEnabled, sliderHeight, sliderWidth } = nextProps;
         const itemsLength = this._getCustomDataLength(nextProps);
@@ -263,11 +263,11 @@ export default class Carousel extends Component {
         }
 
         if (nextProps.onScroll !== this.props.onScroll) {
-            this._setScrollHandler(nextProps);
+          this._setScrollHandler(nextProps);
         }
     }
 
-    componentWillUnmount() {
+    componentWillUnmount () {
         this._mounted = false;
         this.stopAutoplay();
         clearTimeout(this._apparitionTimeout);
@@ -279,69 +279,69 @@ export default class Carousel extends Component {
         clearTimeout(this._lockScrollTimeout);
     }
 
-    get realIndex() {
+    get realIndex () {
         return this._activeItem;
     }
 
-    get currentIndex() {
+    get currentIndex () {
         return this._getDataIndex(this._activeItem);
     }
 
-    get currentScrollPosition() {
+    get currentScrollPosition () {
         return this._currentContentOffset;
     }
 
     _setScrollHandler(props) {
-        // Native driver for scroll events
-        const scrollEventConfig = {
-            listener: this._onScroll,
-            useNativeDriver: true,
-        };
-        this._scrollPos = new Animated.Value(0);
-        const argMapping = props.vertical
-            ? [{ nativeEvent: { contentOffset: { y: this._scrollPos } } }]
-            : [{ nativeEvent: { contentOffset: { x: this._scrollPos } } }];
+      // Native driver for scroll events
+      const scrollEventConfig = {
+        listener: this._onScroll,
+        useNativeDriver: true,
+      };
+      this._scrollPos = new Animated.Value(0);
+      const argMapping = props.vertical
+        ? [{ nativeEvent: { contentOffset: { y: this._scrollPos } } }]
+        : [{ nativeEvent: { contentOffset: { x: this._scrollPos } } }];
 
-        if (props.onScroll && Array.isArray(props.onScroll._argMapping)) {
-            // Because of a react-native issue https://github.com/facebook/react-native/issues/13294
-            argMapping.pop();
-            const [argMap] = props.onScroll._argMapping;
-            if (argMap && argMap.nativeEvent && argMap.nativeEvent.contentOffset) {
-                // Shares the same animated value passed in props
-                this._scrollPos =
-                    argMap.nativeEvent.contentOffset.x ||
-                    argMap.nativeEvent.contentOffset.y ||
-                    this._scrollPos;
-            }
-            argMapping.push(...props.onScroll._argMapping);
+      if (props.onScroll && Array.isArray(props.onScroll._argMapping)) {
+        // Because of a react-native issue https://github.com/facebook/react-native/issues/13294
+        argMapping.pop();
+        const [ argMap ] = props.onScroll._argMapping;
+        if (argMap && argMap.nativeEvent && argMap.nativeEvent.contentOffset) {
+          // Shares the same animated value passed in props
+          this._scrollPos =
+            argMap.nativeEvent.contentOffset.x ||
+            argMap.nativeEvent.contentOffset.y ||
+            this._scrollPos;
         }
-        this._onScrollHandler = Animated.event(
-            argMapping,
-            scrollEventConfig
-        );
+        argMapping.push(...props.onScroll._argMapping);
+      }
+      this._onScrollHandler = Animated.event(
+        argMapping,
+        scrollEventConfig
+      );
     }
 
-    _needsScrollView() {
+    _needsScrollView () {
         const { useScrollView } = this.props;
         return useScrollView || !AnimatedFlatList || this._shouldUseStackLayout() || this._shouldUseTinderLayout();
     }
 
-    _needsRTLAdaptations() {
+    _needsRTLAdaptations () {
         const { vertical } = this.props;
         return IS_RTL && !IS_IOS && !vertical;
     }
 
-    _canLockScroll() {
+    _canLockScroll () {
         const { scrollEnabled, enableMomentum, lockScrollWhileSnapping } = this.props;
         return scrollEnabled && !enableMomentum && lockScrollWhileSnapping;
     }
 
-    _enableLoop() {
+    _enableLoop () {
         const { data, enableSnap, loop } = this.props;
         return enableSnap && loop && data && data.length && data.length > 1;
     }
 
-    _shouldAnimateSlides(props = this.props) {
+    _shouldAnimateSlides (props = this.props) {
         const { inactiveSlideOpacity, inactiveSlideScale, scrollInterpolator, slideInterpolatedStyle } = props;
         return inactiveSlideOpacity < 1 ||
             inactiveSlideScale < 1 ||
@@ -352,25 +352,25 @@ export default class Carousel extends Component {
             this._shouldUseTinderLayout();
     }
 
-    _shouldUseCustomAnimation() {
+    _shouldUseCustomAnimation () {
         const { activeAnimationOptions } = this.props;
         return !!activeAnimationOptions && !this._shouldUseStackLayout() && !this._shouldUseTinderLayout();
     }
 
-    _shouldUseShiftLayout() {
+    _shouldUseShiftLayout () {
         const { inactiveSlideShift, layout } = this.props;
         return layout === 'default' && inactiveSlideShift !== 0;
     }
 
-    _shouldUseStackLayout() {
+    _shouldUseStackLayout () {
         return this.props.layout === 'stack';
     }
 
-    _shouldUseTinderLayout() {
+    _shouldUseTinderLayout () {
         return this.props.layout === 'tinder';
     }
 
-    _getCustomData(props = this.props) {
+    _getCustomData (props = this.props) {
         const { data, loopClonesPerSide } = props;
         const dataLength = data && data.length;
 
@@ -404,7 +404,7 @@ export default class Carousel extends Component {
         return previousItems.concat(data, nextItems);
     }
 
-    _getCustomDataLength(props = this.props) {
+    _getCustomDataLength (props = this.props) {
         const { data, loopClonesPerSide } = props;
         const dataLength = data && data.length;
 
@@ -415,7 +415,7 @@ export default class Carousel extends Component {
         return this._enableLoop() ? dataLength + (2 * loopClonesPerSide) : dataLength;
     }
 
-    _getCustomIndex(index, props = this.props) {
+    _getCustomIndex (index, props = this.props) {
         const itemsLength = this._getCustomDataLength(props);
 
         if (!itemsLength || (!index && index !== 0)) {
@@ -425,7 +425,7 @@ export default class Carousel extends Component {
         return this._needsRTLAdaptations() ? itemsLength - index - 1 : index;
     }
 
-    _getDataIndex(index) {
+    _getDataIndex (index) {
         const { data, loopClonesPerSide } = this.props;
         const dataLength = data && data.length;
 
@@ -464,12 +464,12 @@ export default class Carousel extends Component {
     }
 
     // Used with `snapToItem()` and 'PaginationDot'
-    _getPositionIndex(index) {
+    _getPositionIndex (index) {
         const { loop, loopClonesPerSide } = this.props;
         return loop ? index + loopClonesPerSide : index;
     }
 
-    _getFirstItem(index, props = this.props) {
+    _getFirstItem (index, props = this.props) {
         const { loopClonesPerSide } = props;
         const itemsLength = this._getCustomDataLength(props);
 
@@ -480,17 +480,17 @@ export default class Carousel extends Component {
         return this._enableLoop() ? index + loopClonesPerSide : index;
     }
 
-    _getWrappedRef() {
+    _getWrappedRef () {
         // https://github.com/facebook/react-native/issues/10635
         // https://stackoverflow.com/a/48786374/8412141
         return this._carouselRef && this._carouselRef.getNode && this._carouselRef.getNode();
     }
 
-    _getScrollEnabled() {
+    _getScrollEnabled () {
         return this._scrollEnabled;
     }
 
-    _setScrollEnabled(scrollEnabled = true) {
+    _setScrollEnabled (scrollEnabled = true) {
         const wrappedRef = this._getWrappedRef();
 
         if (!wrappedRef || !wrappedRef.setNativeProps) {
@@ -503,17 +503,17 @@ export default class Carousel extends Component {
         this._scrollEnabled = scrollEnabled;
     }
 
-    _getKeyExtractor(item, index) {
+    _getKeyExtractor (item, index) {
         return this._needsScrollView() ? `scrollview-item-${index}` : `flatlist-item-${index}`;
     }
 
-    _getScrollOffset(event) {
+    _getScrollOffset (event) {
         const { vertical } = this.props;
         return (event && event.nativeEvent && event.nativeEvent.contentOffset &&
             event.nativeEvent.contentOffset[vertical ? 'y' : 'x']) || 0;
     }
 
-    _getContainerInnerMargin(opposite = false) {
+    _getContainerInnerMargin (opposite = false) {
         const { sliderWidth, sliderHeight, itemWidth, itemHeight, vertical, activeSlideAlignment } = this.props;
 
         if ((activeSlideAlignment === 'start' && !opposite) ||
@@ -527,7 +527,7 @@ export default class Carousel extends Component {
         }
     }
 
-    _getViewportOffset() {
+    _getViewportOffset () {
         const { sliderWidth, sliderHeight, itemWidth, itemHeight, vertical, activeSlideAlignment } = this.props;
 
         if (activeSlideAlignment === 'start') {
@@ -541,11 +541,11 @@ export default class Carousel extends Component {
         }
     }
 
-    _getCenter(offset) {
+    _getCenter (offset) {
         return offset + this._getViewportOffset() - this._getContainerInnerMargin();
     }
 
-    _getActiveItem(offset) {
+    _getActiveItem (offset) {
         const { activeSlideOffset, swipeThreshold } = this.props;
         const center = this._getCenter(offset);
         const centerOffset = activeSlideOffset || swipeThreshold;
@@ -565,7 +565,7 @@ export default class Carousel extends Component {
         return 0;
     }
 
-    _initPositionsAndInterpolators(props = this.props) {
+    _initPositionsAndInterpolators (props = this.props) {
         const { data, itemWidth, itemHeight, scrollInterpolator, vertical } = props;
         const sizeRef = vertical ? itemHeight : itemWidth;
 
@@ -616,7 +616,7 @@ export default class Carousel extends Component {
         this.setState({ interpolators });
     }
 
-    _getSlideAnimation(index, toValue) {
+    _getSlideAnimation (index, toValue) {
         const { interpolators } = this.state;
         const { activeAnimationType, activeAnimationOptions } = this.props;
 
@@ -645,7 +645,7 @@ export default class Carousel extends Component {
         ]);
     }
 
-    _playCustomSlideAnimation(current, next) {
+    _playCustomSlideAnimation (current, next) {
         const { interpolators } = this.state;
         const itemsLength = this._getCustomDataLength();
         const _currentIndex = this._getCustomIndex(current);
@@ -675,7 +675,7 @@ export default class Carousel extends Component {
         Animated.parallel(animations, { stopTogether: false }).start();
     }
 
-    _hackActiveSlideAnimation(index, goTo, force = false) {
+    _hackActiveSlideAnimation (index, goTo, force = false) {
         const { data } = this.props;
 
         if (!this._mounted || !this._carouselRef || !this._positions[index] || (!force && this._enableLoop())) {
@@ -699,7 +699,7 @@ export default class Carousel extends Component {
         }, 50); // works randomly when set to '0'
     }
 
-    _lockScroll() {
+    _lockScroll () {
         const { lockScrollTimeoutDuration } = this.props;
         clearTimeout(this._lockScrollTimeout);
         this._lockScrollTimeout = setTimeout(() => {
@@ -708,12 +708,12 @@ export default class Carousel extends Component {
         this._setScrollEnabled(false);
     }
 
-    _releaseScroll() {
+    _releaseScroll () {
         clearTimeout(this._lockScrollTimeout);
         this._setScrollEnabled(true);
     }
 
-    _repositionScroll(index) {
+    _repositionScroll (index) {
         const { data, loopClonesPerSide } = this.props;
         const dataLength = data && data.length;
 
@@ -733,7 +733,7 @@ export default class Carousel extends Component {
         this._snapToItem(repositionTo, false, false, false, false);
     }
 
-    _scrollTo(offset, animated = true) {
+    _scrollTo (offset, animated = true) {
         const { vertical } = this.props;
         const wrappedRef = this._getWrappedRef();
 
@@ -745,8 +745,8 @@ export default class Carousel extends Component {
             x: vertical ? 0 : offset,
             y: vertical ? offset : 0
         } : {
-                offset
-            };
+            offset
+        };
         const options = {
             ...specificOptions,
             animated
@@ -759,7 +759,7 @@ export default class Carousel extends Component {
         }
     }
 
-    _onScroll(event) {
+    _onScroll (event) {
         const { callbackOffsetMargin, enableMomentum, onScroll } = this.props;
 
         const scrollOffset = event ? this._getScrollOffset(event) : this._currentContentOffset;
@@ -821,7 +821,7 @@ export default class Carousel extends Component {
         }
     }
 
-    _onStartShouldSetResponderCapture(event) {
+    _onStartShouldSetResponderCapture (event) {
         const { onStartShouldSetResponderCapture } = this.props;
 
         if (onStartShouldSetResponderCapture) {
@@ -831,7 +831,7 @@ export default class Carousel extends Component {
         return this._getScrollEnabled();
     }
 
-    _onTouchStart() {
+    _onTouchStart () {
         const { onTouchStart } = this.props
 
         // `onTouchStart` is fired even when `scrollEnabled` is set to `false`
@@ -844,7 +844,7 @@ export default class Carousel extends Component {
         }
     }
 
-    _onTouchEnd() {
+    _onTouchEnd () {
         const { onTouchEnd } = this.props
 
         if (this._getScrollEnabled() !== false && autoplay && !this._autoplaying) {
@@ -858,7 +858,7 @@ export default class Carousel extends Component {
     }
 
     // Used when `enableSnap` is ENABLED
-    _onScrollBeginDrag(event) {
+    _onScrollBeginDrag (event) {
         const { onScrollBeginDrag } = this.props;
 
         if (!this._getScrollEnabled()) {
@@ -876,7 +876,7 @@ export default class Carousel extends Component {
     }
 
     // Used when `enableMomentum` is DISABLED
-    _onScrollEndDrag(event) {
+    _onScrollEndDrag (event) {
         const { onScrollEndDrag } = this.props;
 
         if (this._carouselRef) {
@@ -889,7 +889,7 @@ export default class Carousel extends Component {
     }
 
     // Used when `enableMomentum` is ENABLED
-    _onMomentumScrollEnd(event) {
+    _onMomentumScrollEnd (event) {
         const { onMomentumScrollEnd } = this.props;
 
         if (this._carouselRef) {
@@ -901,7 +901,7 @@ export default class Carousel extends Component {
         }
     }
 
-    _onScrollEnd(event) {
+    _onScrollEnd (event) {
         const { autoplay, autoplayDelay, enableSnap } = this.props;
 
         if (this._ignoreNextMomentum) {
@@ -930,7 +930,7 @@ export default class Carousel extends Component {
     // Due to a bug, this event is only fired on iOS
     // https://github.com/facebook/react-native/issues/6791
     // it's fine since we're only fixing an iOS bug in it, so ...
-    _onTouchRelease(event) {
+    _onTouchRelease (event) {
         const { enableMomentum } = this.props;
 
         if (enableMomentum && IS_IOS) {
@@ -941,7 +941,7 @@ export default class Carousel extends Component {
         }
     }
 
-    _onLayout(event) {
+    _onLayout (event) {
         const { onLayout } = this.props;
 
         // Prevent unneeded actions during the first 'onLayout' (triggered on init)
@@ -957,7 +957,7 @@ export default class Carousel extends Component {
         }
     }
 
-    _snapScroll(delta) {
+    _snapScroll (delta) {
         const { swipeThreshold } = this.props;
 
         // When using momentum and releasing the touch with
@@ -990,7 +990,7 @@ export default class Carousel extends Component {
         }
     }
 
-    _snapToItem(index, animated = true, fireCallback = true, initial = false, lockScroll = true) {
+    _snapToItem (index, animated = true, fireCallback = true, initial = false, lockScroll = true) {
         const { enableMomentum, onSnapToItem, onBeforeSnapToItem } = this.props;
         const itemsLength = this._getCustomDataLength();
         const wrappedRef = this._getWrappedRef();
@@ -1057,7 +1057,7 @@ export default class Carousel extends Component {
         }
     }
 
-    _onBeforeSnap(index) {
+    _onBeforeSnap (index) {
         const { onBeforeSnapToItem } = this.props;
 
         if (!this._carouselRef) {
@@ -1068,7 +1068,7 @@ export default class Carousel extends Component {
         onBeforeSnapToItem && onBeforeSnapToItem(index);
     }
 
-    _onSnap(index) {
+    _onSnap (index) {
         const { onSnapToItem } = this.props;
 
         if (!this._carouselRef) {
@@ -1079,7 +1079,7 @@ export default class Carousel extends Component {
         onSnapToItem && onSnapToItem(index);
     }
 
-    startAutoplay() {
+    startAutoplay () {
         const { autoplayInterval, autoplayDelay } = this.props;
 
         if (this._autoplaying) {
@@ -1097,12 +1097,12 @@ export default class Carousel extends Component {
         }, autoplayDelay);
     }
 
-    stopAutoplay() {
+    stopAutoplay () {
         this._autoplaying = false;
         clearInterval(this._autoplayInterval);
     }
 
-    snapToItem(index, animated = true, fireCallback = true) {
+    snapToItem (index, animated = true, fireCallback = true) {
         if (!index || index < 0) {
             index = 0;
         }
@@ -1116,7 +1116,7 @@ export default class Carousel extends Component {
         this._snapToItem(positionIndex, animated, fireCallback);
     }
 
-    snapToNext(animated = true, fireCallback = true) {
+    snapToNext (animated = true, fireCallback = true) {
         const itemsLength = this._getCustomDataLength();
 
         let newIndex = this._activeItem + 1;
@@ -1129,7 +1129,7 @@ export default class Carousel extends Component {
         this._snapToItem(newIndex, animated, fireCallback);
     }
 
-    snapToPrev(animated = true, fireCallback = true) {
+    snapToPrev (animated = true, fireCallback = true) {
         const itemsLength = this._getCustomDataLength();
 
         let newIndex = this._activeItem - 1;
@@ -1143,7 +1143,7 @@ export default class Carousel extends Component {
     }
 
     // https://github.com/facebook/react-native/issues/1831#issuecomment-231069668
-    triggerRenderingHack(offset) {
+    triggerRenderingHack (offset) {
         // Avoid messing with user scroll
         if (Date.now() - this._lastScrollDate < 500) {
             return;
@@ -1158,7 +1158,7 @@ export default class Carousel extends Component {
         this._scrollTo(scrollPosition + scrollOffset, false);
     }
 
-    _getSlideInterpolatedStyle(index, animatedValue) {
+    _getSlideInterpolatedStyle (index, animatedValue) {
         const { layoutCardOffset, slideInterpolatedStyle } = this.props;
 
         if (slideInterpolatedStyle) {
@@ -1174,7 +1174,7 @@ export default class Carousel extends Component {
         }
     }
 
-    _renderItem({ item, index }) {
+    _renderItem ({ item, index }) {
         const { interpolators } = this.state;
         const {
             hasParallaxImages,
@@ -1215,12 +1215,12 @@ export default class Carousel extends Component {
 
         return (
             <Component style={[mainDimension, slideStyle, animatedStyle]} pointerEvents={'box-none'} {...specificProps}>
-                {renderItem({ item, index }, parallaxProps)}
+                { renderItem({ item, index }, parallaxProps) }
             </Component>
         );
     }
 
-    _getComponentOverridableProps() {
+    _getComponentOverridableProps () {
         const {
             enableMomentum,
             itemWidth,
@@ -1262,7 +1262,7 @@ export default class Carousel extends Component {
         };
     }
 
-    _getComponentStaticProps() {
+    _getComponentStaticProps () {
         const { hideCarousel } = this.state;
         const {
             containerCustomStyle,
@@ -1288,9 +1288,9 @@ export default class Carousel extends Component {
                 paddingTop: this._getContainerInnerMargin(),
                 paddingBottom: this._getContainerInnerMargin(true)
             } : {
-                    paddingLeft: this._getContainerInnerMargin(),
-                    paddingRight: this._getContainerInnerMargin(true)
-                },
+                paddingLeft: this._getContainerInnerMargin(),
+                paddingRight: this._getContainerInnerMargin(true)
+            },
             contentContainerCustomStyle || {}
         ];
 
@@ -1323,7 +1323,7 @@ export default class Carousel extends Component {
         };
     }
 
-    render() {
+    render () {
         const { data, renderItem, useScrollView } = this.props;
 
         if (!data || !renderItem) {
@@ -1347,7 +1347,7 @@ export default class Carousel extends Component {
                 }
             </ScrollViewComponent>
         ) : (
-                <AnimatedFlatList {...props} />
-            );
+            <AnimatedFlatList {...props} />
+        );
     }
 }

--- a/src/carousel/Carousel.js
+++ b/src/carousel/Carousel.js
@@ -102,7 +102,7 @@ export default class Carousel extends Component {
         vertical: false
     }
 
-    constructor (props) {
+    constructor(props) {
         super(props);
 
         this.state = {
@@ -171,7 +171,7 @@ export default class Carousel extends Component {
         }
     }
 
-    componentDidMount () {
+    componentDidMount() {
         const { apparitionDelay, autoplay, firstItem } = this.props;
         const _firstItem = this._getFirstItem(firstItem);
         const apparitionCallback = () => {
@@ -203,7 +203,7 @@ export default class Carousel extends Component {
         });
     }
 
-    shouldComponentUpdate (nextProps, nextState) {
+    shouldComponentUpdate(nextProps, nextState) {
         if (this.props.shouldOptimizeUpdates === false) {
             return true;
         } else {
@@ -211,7 +211,7 @@ export default class Carousel extends Component {
         }
     }
 
-    componentWillReceiveProps (nextProps) {
+    componentWillReceiveProps(nextProps) {
         const { interpolators } = this.state;
         const { firstItem, itemHeight, itemWidth, scrollEnabled, sliderHeight, sliderWidth } = nextProps;
         const itemsLength = this._getCustomDataLength(nextProps);
@@ -263,11 +263,11 @@ export default class Carousel extends Component {
         }
 
         if (nextProps.onScroll !== this.props.onScroll) {
-          this._setScrollHandler(nextProps);
+            this._setScrollHandler(nextProps);
         }
     }
 
-    componentWillUnmount () {
+    componentWillUnmount() {
         this._mounted = false;
         this.stopAutoplay();
         clearTimeout(this._apparitionTimeout);
@@ -279,69 +279,69 @@ export default class Carousel extends Component {
         clearTimeout(this._lockScrollTimeout);
     }
 
-    get realIndex () {
+    get realIndex() {
         return this._activeItem;
     }
 
-    get currentIndex () {
+    get currentIndex() {
         return this._getDataIndex(this._activeItem);
     }
 
-    get currentScrollPosition () {
+    get currentScrollPosition() {
         return this._currentContentOffset;
     }
 
     _setScrollHandler(props) {
-      // Native driver for scroll events
-      const scrollEventConfig = {
-        listener: this._onScroll,
-        useNativeDriver: true,
-      };
-      this._scrollPos = new Animated.Value(0);
-      const argMapping = props.vertical
-        ? [{ nativeEvent: { contentOffset: { y: this._scrollPos } } }]
-        : [{ nativeEvent: { contentOffset: { x: this._scrollPos } } }];
+        // Native driver for scroll events
+        const scrollEventConfig = {
+            listener: this._onScroll,
+            useNativeDriver: true,
+        };
+        this._scrollPos = new Animated.Value(0);
+        const argMapping = props.vertical
+            ? [{ nativeEvent: { contentOffset: { y: this._scrollPos } } }]
+            : [{ nativeEvent: { contentOffset: { x: this._scrollPos } } }];
 
-      if (props.onScroll && Array.isArray(props.onScroll._argMapping)) {
-        // Because of a react-native issue https://github.com/facebook/react-native/issues/13294
-        argMapping.pop();
-        const [ argMap ] = props.onScroll._argMapping;
-        if (argMap && argMap.nativeEvent && argMap.nativeEvent.contentOffset) {
-          // Shares the same animated value passed in props
-          this._scrollPos =
-            argMap.nativeEvent.contentOffset.x ||
-            argMap.nativeEvent.contentOffset.y ||
-            this._scrollPos;
+        if (props.onScroll && Array.isArray(props.onScroll._argMapping)) {
+            // Because of a react-native issue https://github.com/facebook/react-native/issues/13294
+            argMapping.pop();
+            const [argMap] = props.onScroll._argMapping;
+            if (argMap && argMap.nativeEvent && argMap.nativeEvent.contentOffset) {
+                // Shares the same animated value passed in props
+                this._scrollPos =
+                    argMap.nativeEvent.contentOffset.x ||
+                    argMap.nativeEvent.contentOffset.y ||
+                    this._scrollPos;
+            }
+            argMapping.push(...props.onScroll._argMapping);
         }
-        argMapping.push(...props.onScroll._argMapping);
-      }
-      this._onScrollHandler = Animated.event(
-        argMapping,
-        scrollEventConfig
-      );
+        this._onScrollHandler = Animated.event(
+            argMapping,
+            scrollEventConfig
+        );
     }
 
-    _needsScrollView () {
+    _needsScrollView() {
         const { useScrollView } = this.props;
         return useScrollView || !AnimatedFlatList || this._shouldUseStackLayout() || this._shouldUseTinderLayout();
     }
 
-    _needsRTLAdaptations () {
+    _needsRTLAdaptations() {
         const { vertical } = this.props;
         return IS_RTL && !IS_IOS && !vertical;
     }
 
-    _canLockScroll () {
+    _canLockScroll() {
         const { scrollEnabled, enableMomentum, lockScrollWhileSnapping } = this.props;
         return scrollEnabled && !enableMomentum && lockScrollWhileSnapping;
     }
 
-    _enableLoop () {
+    _enableLoop() {
         const { data, enableSnap, loop } = this.props;
         return enableSnap && loop && data && data.length && data.length > 1;
     }
 
-    _shouldAnimateSlides (props = this.props) {
+    _shouldAnimateSlides(props = this.props) {
         const { inactiveSlideOpacity, inactiveSlideScale, scrollInterpolator, slideInterpolatedStyle } = props;
         return inactiveSlideOpacity < 1 ||
             inactiveSlideScale < 1 ||
@@ -352,25 +352,25 @@ export default class Carousel extends Component {
             this._shouldUseTinderLayout();
     }
 
-    _shouldUseCustomAnimation () {
+    _shouldUseCustomAnimation() {
         const { activeAnimationOptions } = this.props;
         return !!activeAnimationOptions && !this._shouldUseStackLayout() && !this._shouldUseTinderLayout();
     }
 
-    _shouldUseShiftLayout () {
+    _shouldUseShiftLayout() {
         const { inactiveSlideShift, layout } = this.props;
         return layout === 'default' && inactiveSlideShift !== 0;
     }
 
-    _shouldUseStackLayout () {
+    _shouldUseStackLayout() {
         return this.props.layout === 'stack';
     }
 
-    _shouldUseTinderLayout () {
+    _shouldUseTinderLayout() {
         return this.props.layout === 'tinder';
     }
 
-    _getCustomData (props = this.props) {
+    _getCustomData(props = this.props) {
         const { data, loopClonesPerSide } = props;
         const dataLength = data && data.length;
 
@@ -404,7 +404,7 @@ export default class Carousel extends Component {
         return previousItems.concat(data, nextItems);
     }
 
-    _getCustomDataLength (props = this.props) {
+    _getCustomDataLength(props = this.props) {
         const { data, loopClonesPerSide } = props;
         const dataLength = data && data.length;
 
@@ -415,7 +415,7 @@ export default class Carousel extends Component {
         return this._enableLoop() ? dataLength + (2 * loopClonesPerSide) : dataLength;
     }
 
-    _getCustomIndex (index, props = this.props) {
+    _getCustomIndex(index, props = this.props) {
         const itemsLength = this._getCustomDataLength(props);
 
         if (!itemsLength || (!index && index !== 0)) {
@@ -425,7 +425,7 @@ export default class Carousel extends Component {
         return this._needsRTLAdaptations() ? itemsLength - index - 1 : index;
     }
 
-    _getDataIndex (index) {
+    _getDataIndex(index) {
         const { data, loopClonesPerSide } = this.props;
         const dataLength = data && data.length;
 
@@ -464,12 +464,12 @@ export default class Carousel extends Component {
     }
 
     // Used with `snapToItem()` and 'PaginationDot'
-    _getPositionIndex (index) {
+    _getPositionIndex(index) {
         const { loop, loopClonesPerSide } = this.props;
         return loop ? index + loopClonesPerSide : index;
     }
 
-    _getFirstItem (index, props = this.props) {
+    _getFirstItem(index, props = this.props) {
         const { loopClonesPerSide } = props;
         const itemsLength = this._getCustomDataLength(props);
 
@@ -480,17 +480,17 @@ export default class Carousel extends Component {
         return this._enableLoop() ? index + loopClonesPerSide : index;
     }
 
-    _getWrappedRef () {
+    _getWrappedRef() {
         // https://github.com/facebook/react-native/issues/10635
         // https://stackoverflow.com/a/48786374/8412141
         return this._carouselRef && this._carouselRef.getNode && this._carouselRef.getNode();
     }
 
-    _getScrollEnabled () {
+    _getScrollEnabled() {
         return this._scrollEnabled;
     }
 
-    _setScrollEnabled (scrollEnabled = true) {
+    _setScrollEnabled(scrollEnabled = true) {
         const wrappedRef = this._getWrappedRef();
 
         if (!wrappedRef || !wrappedRef.setNativeProps) {
@@ -503,17 +503,17 @@ export default class Carousel extends Component {
         this._scrollEnabled = scrollEnabled;
     }
 
-    _getKeyExtractor (item, index) {
+    _getKeyExtractor(item, index) {
         return this._needsScrollView() ? `scrollview-item-${index}` : `flatlist-item-${index}`;
     }
 
-    _getScrollOffset (event) {
+    _getScrollOffset(event) {
         const { vertical } = this.props;
         return (event && event.nativeEvent && event.nativeEvent.contentOffset &&
             event.nativeEvent.contentOffset[vertical ? 'y' : 'x']) || 0;
     }
 
-    _getContainerInnerMargin (opposite = false) {
+    _getContainerInnerMargin(opposite = false) {
         const { sliderWidth, sliderHeight, itemWidth, itemHeight, vertical, activeSlideAlignment } = this.props;
 
         if ((activeSlideAlignment === 'start' && !opposite) ||
@@ -527,7 +527,7 @@ export default class Carousel extends Component {
         }
     }
 
-    _getViewportOffset () {
+    _getViewportOffset() {
         const { sliderWidth, sliderHeight, itemWidth, itemHeight, vertical, activeSlideAlignment } = this.props;
 
         if (activeSlideAlignment === 'start') {
@@ -541,11 +541,11 @@ export default class Carousel extends Component {
         }
     }
 
-    _getCenter (offset) {
+    _getCenter(offset) {
         return offset + this._getViewportOffset() - this._getContainerInnerMargin();
     }
 
-    _getActiveItem (offset) {
+    _getActiveItem(offset) {
         const { activeSlideOffset, swipeThreshold } = this.props;
         const center = this._getCenter(offset);
         const centerOffset = activeSlideOffset || swipeThreshold;
@@ -565,7 +565,7 @@ export default class Carousel extends Component {
         return 0;
     }
 
-    _initPositionsAndInterpolators (props = this.props) {
+    _initPositionsAndInterpolators(props = this.props) {
         const { data, itemWidth, itemHeight, scrollInterpolator, vertical } = props;
         const sizeRef = vertical ? itemHeight : itemWidth;
 
@@ -616,7 +616,7 @@ export default class Carousel extends Component {
         this.setState({ interpolators });
     }
 
-    _getSlideAnimation (index, toValue) {
+    _getSlideAnimation(index, toValue) {
         const { interpolators } = this.state;
         const { activeAnimationType, activeAnimationOptions } = this.props;
 
@@ -645,7 +645,7 @@ export default class Carousel extends Component {
         ]);
     }
 
-    _playCustomSlideAnimation (current, next) {
+    _playCustomSlideAnimation(current, next) {
         const { interpolators } = this.state;
         const itemsLength = this._getCustomDataLength();
         const _currentIndex = this._getCustomIndex(current);
@@ -675,7 +675,7 @@ export default class Carousel extends Component {
         Animated.parallel(animations, { stopTogether: false }).start();
     }
 
-    _hackActiveSlideAnimation (index, goTo, force = false) {
+    _hackActiveSlideAnimation(index, goTo, force = false) {
         const { data } = this.props;
 
         if (!this._mounted || !this._carouselRef || !this._positions[index] || (!force && this._enableLoop())) {
@@ -699,7 +699,7 @@ export default class Carousel extends Component {
         }, 50); // works randomly when set to '0'
     }
 
-    _lockScroll () {
+    _lockScroll() {
         const { lockScrollTimeoutDuration } = this.props;
         clearTimeout(this._lockScrollTimeout);
         this._lockScrollTimeout = setTimeout(() => {
@@ -708,12 +708,12 @@ export default class Carousel extends Component {
         this._setScrollEnabled(false);
     }
 
-    _releaseScroll () {
+    _releaseScroll() {
         clearTimeout(this._lockScrollTimeout);
         this._setScrollEnabled(true);
     }
 
-    _repositionScroll (index) {
+    _repositionScroll(index) {
         const { data, loopClonesPerSide } = this.props;
         const dataLength = data && data.length;
 
@@ -733,7 +733,7 @@ export default class Carousel extends Component {
         this._snapToItem(repositionTo, false, false, false, false);
     }
 
-    _scrollTo (offset, animated = true) {
+    _scrollTo(offset, animated = true) {
         const { vertical } = this.props;
         const wrappedRef = this._getWrappedRef();
 
@@ -745,8 +745,8 @@ export default class Carousel extends Component {
             x: vertical ? 0 : offset,
             y: vertical ? offset : 0
         } : {
-            offset
-        };
+                offset
+            };
         const options = {
             ...specificOptions,
             animated
@@ -759,7 +759,7 @@ export default class Carousel extends Component {
         }
     }
 
-    _onScroll (event) {
+    _onScroll(event) {
         const { callbackOffsetMargin, enableMomentum, onScroll } = this.props;
 
         const scrollOffset = event ? this._getScrollOffset(event) : this._currentContentOffset;
@@ -821,7 +821,7 @@ export default class Carousel extends Component {
         }
     }
 
-    _onStartShouldSetResponderCapture (event) {
+    _onStartShouldSetResponderCapture(event) {
         const { onStartShouldSetResponderCapture } = this.props;
 
         if (onStartShouldSetResponderCapture) {
@@ -831,7 +831,7 @@ export default class Carousel extends Component {
         return this._getScrollEnabled();
     }
 
-    _onTouchStart () {
+    _onTouchStart() {
         const { onTouchStart } = this.props
 
         // `onTouchStart` is fired even when `scrollEnabled` is set to `false`
@@ -844,7 +844,7 @@ export default class Carousel extends Component {
         }
     }
 
-    _onTouchEnd () {
+    _onTouchEnd() {
         const { onTouchEnd } = this.props
 
         if (this._getScrollEnabled() !== false && autoplay && !this._autoplaying) {
@@ -858,7 +858,7 @@ export default class Carousel extends Component {
     }
 
     // Used when `enableSnap` is ENABLED
-    _onScrollBeginDrag (event) {
+    _onScrollBeginDrag(event) {
         const { onScrollBeginDrag } = this.props;
 
         if (!this._getScrollEnabled()) {
@@ -876,7 +876,7 @@ export default class Carousel extends Component {
     }
 
     // Used when `enableMomentum` is DISABLED
-    _onScrollEndDrag (event) {
+    _onScrollEndDrag(event) {
         const { onScrollEndDrag } = this.props;
 
         if (this._carouselRef) {
@@ -889,7 +889,7 @@ export default class Carousel extends Component {
     }
 
     // Used when `enableMomentum` is ENABLED
-    _onMomentumScrollEnd (event) {
+    _onMomentumScrollEnd(event) {
         const { onMomentumScrollEnd } = this.props;
 
         if (this._carouselRef) {
@@ -901,7 +901,7 @@ export default class Carousel extends Component {
         }
     }
 
-    _onScrollEnd (event) {
+    _onScrollEnd(event) {
         const { autoplay, autoplayDelay, enableSnap } = this.props;
 
         if (this._ignoreNextMomentum) {
@@ -930,7 +930,7 @@ export default class Carousel extends Component {
     // Due to a bug, this event is only fired on iOS
     // https://github.com/facebook/react-native/issues/6791
     // it's fine since we're only fixing an iOS bug in it, so ...
-    _onTouchRelease (event) {
+    _onTouchRelease(event) {
         const { enableMomentum } = this.props;
 
         if (enableMomentum && IS_IOS) {
@@ -941,7 +941,7 @@ export default class Carousel extends Component {
         }
     }
 
-    _onLayout (event) {
+    _onLayout(event) {
         const { onLayout } = this.props;
 
         // Prevent unneeded actions during the first 'onLayout' (triggered on init)
@@ -957,7 +957,7 @@ export default class Carousel extends Component {
         }
     }
 
-    _snapScroll (delta) {
+    _snapScroll(delta) {
         const { swipeThreshold } = this.props;
 
         // When using momentum and releasing the touch with
@@ -990,7 +990,7 @@ export default class Carousel extends Component {
         }
     }
 
-    _snapToItem (index, animated = true, fireCallback = true, initial = false, lockScroll = true) {
+    _snapToItem(index, animated = true, fireCallback = true, initial = false, lockScroll = true) {
         const { enableMomentum, onSnapToItem, onBeforeSnapToItem } = this.props;
         const itemsLength = this._getCustomDataLength();
         const wrappedRef = this._getWrappedRef();
@@ -1036,7 +1036,7 @@ export default class Carousel extends Component {
 
         if (enableMomentum) {
             // iOS fix, check the note in the constructor
-            if (IS_IOS && !initial) {
+            if (!initial) {
                 this._ignoreNextMomentum = true;
             }
 
@@ -1057,7 +1057,7 @@ export default class Carousel extends Component {
         }
     }
 
-    _onBeforeSnap (index) {
+    _onBeforeSnap(index) {
         const { onBeforeSnapToItem } = this.props;
 
         if (!this._carouselRef) {
@@ -1068,7 +1068,7 @@ export default class Carousel extends Component {
         onBeforeSnapToItem && onBeforeSnapToItem(index);
     }
 
-    _onSnap (index) {
+    _onSnap(index) {
         const { onSnapToItem } = this.props;
 
         if (!this._carouselRef) {
@@ -1079,7 +1079,7 @@ export default class Carousel extends Component {
         onSnapToItem && onSnapToItem(index);
     }
 
-    startAutoplay () {
+    startAutoplay() {
         const { autoplayInterval, autoplayDelay } = this.props;
 
         if (this._autoplaying) {
@@ -1097,12 +1097,12 @@ export default class Carousel extends Component {
         }, autoplayDelay);
     }
 
-    stopAutoplay () {
+    stopAutoplay() {
         this._autoplaying = false;
         clearInterval(this._autoplayInterval);
     }
 
-    snapToItem (index, animated = true, fireCallback = true) {
+    snapToItem(index, animated = true, fireCallback = true) {
         if (!index || index < 0) {
             index = 0;
         }
@@ -1116,7 +1116,7 @@ export default class Carousel extends Component {
         this._snapToItem(positionIndex, animated, fireCallback);
     }
 
-    snapToNext (animated = true, fireCallback = true) {
+    snapToNext(animated = true, fireCallback = true) {
         const itemsLength = this._getCustomDataLength();
 
         let newIndex = this._activeItem + 1;
@@ -1129,7 +1129,7 @@ export default class Carousel extends Component {
         this._snapToItem(newIndex, animated, fireCallback);
     }
 
-    snapToPrev (animated = true, fireCallback = true) {
+    snapToPrev(animated = true, fireCallback = true) {
         const itemsLength = this._getCustomDataLength();
 
         let newIndex = this._activeItem - 1;
@@ -1143,7 +1143,7 @@ export default class Carousel extends Component {
     }
 
     // https://github.com/facebook/react-native/issues/1831#issuecomment-231069668
-    triggerRenderingHack (offset) {
+    triggerRenderingHack(offset) {
         // Avoid messing with user scroll
         if (Date.now() - this._lastScrollDate < 500) {
             return;
@@ -1158,7 +1158,7 @@ export default class Carousel extends Component {
         this._scrollTo(scrollPosition + scrollOffset, false);
     }
 
-    _getSlideInterpolatedStyle (index, animatedValue) {
+    _getSlideInterpolatedStyle(index, animatedValue) {
         const { layoutCardOffset, slideInterpolatedStyle } = this.props;
 
         if (slideInterpolatedStyle) {
@@ -1174,7 +1174,7 @@ export default class Carousel extends Component {
         }
     }
 
-    _renderItem ({ item, index }) {
+    _renderItem({ item, index }) {
         const { interpolators } = this.state;
         const {
             hasParallaxImages,
@@ -1215,12 +1215,12 @@ export default class Carousel extends Component {
 
         return (
             <Component style={[mainDimension, slideStyle, animatedStyle]} pointerEvents={'box-none'} {...specificProps}>
-                { renderItem({ item, index }, parallaxProps) }
+                {renderItem({ item, index }, parallaxProps)}
             </Component>
         );
     }
 
-    _getComponentOverridableProps () {
+    _getComponentOverridableProps() {
         const {
             enableMomentum,
             itemWidth,
@@ -1262,7 +1262,7 @@ export default class Carousel extends Component {
         };
     }
 
-    _getComponentStaticProps () {
+    _getComponentStaticProps() {
         const { hideCarousel } = this.state;
         const {
             containerCustomStyle,
@@ -1288,9 +1288,9 @@ export default class Carousel extends Component {
                 paddingTop: this._getContainerInnerMargin(),
                 paddingBottom: this._getContainerInnerMargin(true)
             } : {
-                paddingLeft: this._getContainerInnerMargin(),
-                paddingRight: this._getContainerInnerMargin(true)
-            },
+                    paddingLeft: this._getContainerInnerMargin(),
+                    paddingRight: this._getContainerInnerMargin(true)
+                },
             contentContainerCustomStyle || {}
         ];
 
@@ -1323,7 +1323,7 @@ export default class Carousel extends Component {
         };
     }
 
-    render () {
+    render() {
         const { data, renderItem, useScrollView } = this.props;
 
         if (!data || !renderItem) {
@@ -1347,7 +1347,7 @@ export default class Carousel extends Component {
                 }
             </ScrollViewComponent>
         ) : (
-            <AnimatedFlatList {...props} />
-        );
+                <AnimatedFlatList {...props} />
+            );
     }
 }


### PR DESCRIPTION
### Platforms affected
ANDROID

### What does this PR do?

On Android, when enableMomentum is true, snapToItem no longer works. You are not able to click the next carousel item to navigate through the carousel, only swiping works. It looks like this iOS fix applies to Android in the case of enableMomentum being true, and allows navigation via snapToItem. On the snack.io: https://snack.expo.io/@daaashley/snap-carousel-snaptoitem-bug-android , notice how on iOS emulator you can navigate by clicking, and on Android you cannot. If you merge/try out this change, you will be able to navigate via click/snapToItem on Android. Please let me know your thoughts, comments, advice, etc... 

### What testing has been done on this change?

I have made a snack example to demonstrate the problem and reproduced and fixed the problem locally, a fix which I have submitted here.

https://snack.expo.io/@daaashley/snap-carousel-snaptoitem-bug-android

Relates to this issue: https://github.com/archriss/react-native-snap-carousel/issues/552


### Tested features checklist
<!--
IMPORTANT: Please make sure that none of these features have been broken by your changes.
It's easy to overlook something you didn't use yet.
-->
- [x] Default setup ([example](https://github.com/archriss/react-native-snap-carousel/blob/master/example/src/index.js#L46-L87))
- [x] Carousels with and without momentum enabled ([prop `enableMomentum`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#behavior))
- [ ] Vertical carousels ([prop `vertical`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#behavior))
- [ ] Slide alignment ([prop `activeSlideAlignment`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#style-and-animation))
- [ ] Autoplay ([prop `autoplay`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#autoplay))
- [ ] Loop mode ([prop `loop`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#loop))
- [ ] `ScrollView`/`FlatList` carousels ([prop `useScrollView`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#behavior))
- [x] [Callback methods](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#callbacks)
- [ ] [`ParallaxImage` component](https://github.com/archriss/react-native-snap-carousel#parallaximage-component)
- [ ] [`Pagination` component](https://github.com/archriss/react-native-snap-carousel#pagination-component)
- [ ] [Layouts and custom interpolations](https://github.com/archriss/react-native-snap-carousel#layouts-and-custom-interpolations)
