### PR TITLE
componentWillReceiveProps migrated to componentDidUpdate

### DIFF
--- a/src/carousel/Carousel.js
+++ b/src/carousel/Carousel.js
@@ -211,23 +211,23 @@ export default class Carousel extends Component {
         }
     }
 
-    componentWillReceiveProps (nextProps) {
+    componentDidUpdate (prevProps) {
         const { interpolators } = this.state;
-        const { firstItem, itemHeight, itemWidth, scrollEnabled, sliderHeight, sliderWidth } = nextProps;
-        const itemsLength = this._getCustomDataLength(nextProps);
+        const { firstItem, itemHeight, itemWidth, scrollEnabled, sliderHeight, sliderWidth } = this.props;
+        const itemsLength = this._getCustomDataLength(this.props);
 
         if (!itemsLength) {
             return;
         }
 
-        const nextFirstItem = this._getFirstItem(firstItem, nextProps);
+        const nextFirstItem = this._getFirstItem(firstItem, this.props);
         let nextActiveItem = this._activeItem || this._activeItem === 0 ? this._activeItem : nextFirstItem;
 
-        const hasNewSliderWidth = sliderWidth && sliderWidth !== this.props.sliderWidth;
-        const hasNewSliderHeight = sliderHeight && sliderHeight !== this.props.sliderHeight;
-        const hasNewItemWidth = itemWidth && itemWidth !== this.props.itemWidth;
-        const hasNewItemHeight = itemHeight && itemHeight !== this.props.itemHeight;
-        const hasNewScrollEnabled = scrollEnabled !== this.props.scrollEnabled;
+        const hasNewSliderWidth = sliderWidth && sliderWidth !== prevProps.sliderWidth;
+        const hasNewSliderHeight = sliderHeight && sliderHeight !== prevProps.sliderHeight;
+        const hasNewItemWidth = itemWidth && itemWidth !== prevProps.itemWidth;
+        const hasNewItemHeight = itemHeight && itemHeight !== prevProps.itemHeight;
+        const hasNewScrollEnabled = scrollEnabled !== prevProps.scrollEnabled;
 
         // Prevent issues with dynamically removed items
         if (nextActiveItem > itemsLength - 1) {
@@ -244,7 +244,7 @@ export default class Carousel extends Component {
             this._activeItem = nextActiveItem;
             this._previousItemsLength = itemsLength;
 
-            this._initPositionsAndInterpolators(nextProps);
+            this._initPositionsAndInterpolators(this.props);
 
             // Handle scroll issue when dynamically removing items (see #133)
             // This also fixes first item's active state on Android
@@ -262,8 +262,8 @@ export default class Carousel extends Component {
             this._snapToItem(nextFirstItem, false, true, false, false);
         }
 
-        if (nextProps.onScroll !== this.props.onScroll) {
-          this._setScrollHandler(nextProps);
+        if (this.props.onScroll !== prevProps.onScroll) {
+          this._setScrollHandler(this.props);
         }
     }
 

--- a/src/pagination/PaginationDot.js
+++ b/src/pagination/PaginationDot.js
@@ -35,9 +35,9 @@ export default class PaginationDot extends PureComponent {
         }
     }
 
-    componentWillReceiveProps (nextProps) {
-        if (nextProps.active !== this.props.active) {
-            this._animate(nextProps.active ? 1 : 0);
+    componentDidUpdate (prevProps) {
+        if (prevProps.active !== this.props.active) {
+            this._animate(this.props.active ? 1 : 0);
         }
     }
 


### PR DESCRIPTION
### Platforms affected
iOS and android

### What does this PR do?
removing componentWillReceiveProps deprecated warning

### What testing has been done on this change?
nothing really

### Tested features checklist
<!--
IMPORTANT: Please make sure that none of these features have been broken by your changes.
It's easy to overlook something you didn't use yet.
-->
- [ ] Default setup ([example](https://github.com/archriss/react-native-snap-carousel/blob/master/example/src/index.js#L46-L87))
- [ ] Carousels with and without momentum enabled ([prop `enableMomentum`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#behavior))
- [ ] Vertical carousels ([prop `vertical`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#behavior))
- [ ] Slide alignment ([prop `activeSlideAlignment`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#style-and-animation))
- [ ] Autoplay ([prop `autoplay`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#autoplay))
- [ ] Loop mode ([prop `loop`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#loop))
- [ ] `ScrollView`/`FlatList` carousels ([prop `useScrollView`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#behavior))
- [ ] [Callback methods](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#callbacks)
- [ ] [`ParallaxImage` component](https://github.com/archriss/react-native-snap-carousel#parallaximage-component)
- [ ] [`Pagination` component](https://github.com/archriss/react-native-snap-carousel#pagination-component)
- [ ] [Layouts and custom interpolations](https://github.com/archriss/react-native-snap-carousel#layouts-and-custom-interpolations)
