### PR TITLE
Fix autoplay stops after user interaction

### DIFF
--- a/src/carousel/Carousel.js
+++ b/src/carousel/Carousel.js
@@ -836,7 +836,7 @@ export default class Carousel extends Component {
 
         // `onTouchStart` is fired even when `scrollEnabled` is set to `false`
         if (this._getScrollEnabled() !== false && this._autoplaying) {
-            this.stopAutoplay();
+            this.pauseAutoPlay();
         }
 
         if (onTouchStart) {
@@ -847,7 +847,7 @@ export default class Carousel extends Component {
     _onTouchEnd () {
         const { onTouchEnd } = this.props
 
-        if (this._getScrollEnabled() !== false && autoplay && !this._autoplaying) {
+        if (this._getScrollEnabled() !== false && this._autoplay && !this._autoplaying) {
             // This event is buggy on Android, so a fallback is provided in _onScrollEnd()
             this.startAutoplay();
         }
@@ -902,7 +902,7 @@ export default class Carousel extends Component {
     }
 
     _onScrollEnd (event) {
-        const { autoplay, autoplayDelay, enableSnap } = this.props;
+        const { autoplayDelay, enableSnap } = this.props;
 
         if (this._ignoreNextMomentum) {
             // iOS fix
@@ -919,7 +919,7 @@ export default class Carousel extends Component {
 
         // The touchEnd event is buggy on Android, so this will serve as a fallback whenever needed
         // https://github.com/facebook/react-native/issues/9439
-        if (autoplay && !this._autoplaying) {
+        if (this._autoplay && !this._autoplaying) {
             clearTimeout(this._enableAutoplayTimeout);
             this._enableAutoplayTimeout = setTimeout(() => {
                 this.startAutoplay();
@@ -1081,6 +1081,7 @@ export default class Carousel extends Component {
 
     startAutoplay () {
         const { autoplayInterval, autoplayDelay } = this.props;
+        this._autoplay = true;
 
         if (this._autoplaying) {
             return;
@@ -1097,9 +1098,14 @@ export default class Carousel extends Component {
         }, autoplayDelay);
     }
 
-    stopAutoplay () {
+    pauseAutoPlay () {
         this._autoplaying = false;
-        clearInterval(this._autoplayInterval);
+        clearInterval(this._autoplayInterval);        
+    }
+
+    stopAutoplay () {
+        this._autoplay = false;
+        this.pauseAutoPlay();
     }
 
     snapToItem (index, animated = true, fireCallback = true) {


### PR DESCRIPTION
### Platforms affected
Both iOS and Android

### What does this PR do?
Fix autoplay stops after user interaction https://github.com/archriss/react-native-snap-carousel/issues/452.

### What testing has been done on this change?
Scroll manually if `autoplay = true`, or after calling `startAutoplay`, and it should continue autoplay after scrolling.

### Tested features checklist
<!--
IMPORTANT: Please make sure that none of these features have been broken by your changes.
It's easy to overlook something you didn't use yet.
-->
- [x] Default setup ([example](https://github.com/archriss/react-native-snap-carousel/blob/master/example/src/index.js#L46-L87))
- [x] Carousels with and without momentum enabled ([prop `enableMomentum`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#behavior))
- [x] Vertical carousels ([prop `vertical`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#behavior))
- [x] Slide alignment ([prop `activeSlideAlignment`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#style-and-animation))
- [x] Autoplay ([prop `autoplay`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#autoplay))
- [x] Loop mode ([prop `loop`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#loop))
- [x] `ScrollView`/`FlatList` carousels ([prop `useScrollView`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#behavior))
- [x] [Callback methods](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#callbacks)
- [x] [`ParallaxImage` component](https://github.com/archriss/react-native-snap-carousel#parallaximage-component)
- [x] [`Pagination` component](https://github.com/archriss/react-native-snap-carousel#pagination-component)
- [x] [Layouts and custom interpolations](https://github.com/archriss/react-native-snap-carousel#layouts-and-custom-interpolations)
