### PR TITLE
Clear all timeouts when stopping autoplay

### DIFF
--- a/src/carousel/Carousel.js
+++ b/src/carousel/Carousel.js
@@ -1100,7 +1100,9 @@ export default class Carousel extends Component {
 
     pauseAutoPlay () {
         this._autoplaying = false;
-        clearInterval(this._autoplayInterval);        
+        clearTimeout(this._autoplayTimeout);
+        clearTimeout(this._enableAutoplayTimeout);
+        clearInterval(this._autoplayInterval);
     }
 
     stopAutoplay () {


### PR DESCRIPTION
Those extra `clearTimeout` fixes 2 potential issues with timeouts firing after programatically calling `stopAutoplay()`: 
- If a `stopAutoplay()` is issued while there is an unfulfilled delayed autoplay (because of `autoplayDelay`), the autoplay will start anyway because `_autoplayTimeout` is still up. 
- If the carousel item is clickable, and the click should stop autoplay (with `stopAutoplay()`), because of the `_onScrollEnd` fallback for Android (and the `+50` added to the `autoplayDelay` there), there was a chance that the carousel would continue scrolling automatically.