### PR TITLE
fix(Carousel): onSnapToItem's type definition does not match documentations

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -54,7 +54,7 @@ declare module 'react-native-snap-carousel' {
     useScrollView?: (() => void) | boolean;
     vertical?: boolean;
     onBeforeSnapToItem?: () => void;
-    onSnapToItem?: () => void;
+    onSnapToItem?: (slideIndex: number) => void;
   }
 
   export interface ParallaxImageProps {


### PR DESCRIPTION
### Platforms affected

All platforms when using TypeScript.

### What does this PR do?

This PR fixes a TypeScript bug and aligns `onSnapToItem`'s definition with [the documentation](https://github.com/archriss/react-native-snap-carousel/blob/6730b5ef80aecb40ec147c674e02707509c21f41/doc/PROPS_METHODS_AND_GETTERS.md#callbacks).

Currently `tsc` fails with this:

```
$ tsc --noEmit
src/screens/AccountDetailScreen/AccountSummaryCarousel.tsx:136:11 - error TS2769: No overload matches this call.
  Overload 1 of 2, '(props: Readonly<CarouselProps>): Carousel', gave the following error.
    Type '(activeSlide: number) => void' is not assignable to type '() => void'.
  Overload 2 of 2, '(props: CarouselProps, context?: any): Carousel', gave the following error.
    Type '(activeSlide: number) => void' is not assignable to type '() => void'.

136           onSnapToItem={this.setActiveSlide}
              ~~~~~~~~~~~~

  node_modules/react-native-snap-carousel/src/index.d.ts:57:5
    57     onSnapToItem?: () => void;
           ~~~~~~~~~~~~
    The expected type comes from property 'onSnapToItem' which is declared here on type 'IntrinsicAttributes & IntrinsicClassAttributes<Carousel> & Readonly<
CarouselProps> & Readonly<{ children?: ReactNode; }>'
  node_modules/react-native-snap-carousel/src/index.d.ts:57:5
    57     onSnapToItem?: () => void;
           ~~~~~~~~~~~~
    The expected type comes from property 'onSnapToItem' which is declared here on type 'IntrinsicAttributes & IntrinsicClassAttributes<Carousel> & Readonly<
CarouselProps> & Readonly<{ children?: ReactNode; }>'


Found 1 error.
```

If this change is not made, consumers of this library must work around the issue by ignoring the `tsc` failure with `@ts-ignore`.

### What testing has been done on this change?

I have tested that this change is sufficient for `tsc` to not blow up.

### Tested features checklist
<!--
IMPORTANT: Please make sure that none of these features have been broken by your changes.
It's easy to overlook something you didn't use yet.
-->
- [ ] Default setup ([example](https://github.com/archriss/react-native-snap-carousel/blob/master/example/src/index.js#L46-L87))
- [ ] Carousels with and without momentum enabled ([prop `enableMomentum`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#behavior))
- [ ] Vertical carousels ([prop `vertical`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#behavior))
- [ ] Slide alignment ([prop `activeSlideAlignment`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#style-and-animation))
- [ ] Autoplay ([prop `autoplay`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#autoplay))
- [ ] Loop mode ([prop `loop`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#loop))
- [ ] `ScrollView`/`FlatList` carousels ([prop `useScrollView`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#behavior))
- [ ] [Callback methods](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#callbacks)
- [ ] [`ParallaxImage` component](https://github.com/archriss/react-native-snap-carousel#parallaximage-component)
- [ ] [`Pagination` component](https://github.com/archriss/react-native-snap-carousel#pagination-component)
- [ ] [Layouts and custom interpolations](https://github.com/archriss/react-native-snap-carousel#layouts-and-custom-interpolations)
