### PR TITLE
Fix for onSnapToItem is not fired

### DIFF
--- a/src/carousel/Carousel.js
+++ b/src/carousel/Carousel.js
@@ -877,10 +877,17 @@ export default class Carousel extends Component {
 
     // Used when `enableMomentum` is DISABLED
     _onScrollEndDrag (event) {
-        const { onScrollEndDrag } = this.props;
+        const { onScrollEndDrag, enableSnap } = this.props;
 
         if (this._carouselRef) {
             this._onScrollEnd && this._onScrollEnd();
+
+            /**
+             * When scroll in a right position after calling this._onScrollEnd() and slide is changed,
+             * We will not receive *required onScroll events.
+             * So we can call it now, to make sure sync is completed.
+             */
+            if(enableSnap) this._onScroll(event)
         }
 
         if (onScrollEndDrag) {


### PR DESCRIPTION
We use `<Carousel layout={'default'} />` in our project. We use `onSnapToItem` to define, what user selects. 
Usually we have ~3 screens. Bug is very easy to reproduce for android. You need just to swipe to very start, or very end.
I think it is also related for center like described in:
https://github.com/archriss/react-native-snap-carousel/issues/635

We rely on `onSnapToItem`, and it must show correct index.
Maybe solution looks like workaround, but it solves this annoying problem.
We always get reports that a lot of users get the issue.

I suggest to go with this solution for now, and to change later to more proper way.

### Platforms affected
IOS and Android. 
Mostly android.



