### PR TITLE
Fix for incorrect snapToItem

### DIFF
--- a/src/carousel/Carousel.js
+++ b/src/carousel/Carousel.js
@@ -910,6 +910,10 @@ export default class Carousel extends Component {
             return;
         }
 
+        if (this._currentContentOffset === this._scrollEndOffset) {
+            return;
+        }
+
         this._scrollEndOffset = this._currentContentOffset;
         this._scrollEndActive = this._getActiveItem(this._scrollEndOffset);
 
@@ -1033,6 +1037,8 @@ export default class Carousel extends Component {
         }
 
         this._scrollTo(this._scrollOffsetRef, animated);
+
+        this._scrollEndOffset = this._currentContentOffset;
 
         if (enableMomentum) {
             // iOS fix, check the note in the constructor


### PR DESCRIPTION
### Platforms affected

iOS, Android


### What does this PR do?

Fixed snapToItem not working correctly.


### What testing has been done on this change?

Tested on iOS / Android


### Tested features checklist
<!--
IMPORTANT: Please make sure that none of these features have been broken by your changes.
It's easy to overlook something you didn't use yet.
-->
- [x] Default setup ([example](https://github.com/archriss/react-native-snap-carousel/blob/master/example/src/index.js#L46-L87))
- [ ] Carousels with and without momentum enabled ([prop `enableMomentum`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#behavior))
- [ ] Vertical carousels ([prop `vertical`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#behavior))
- [ ] Slide alignment ([prop `activeSlideAlignment`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#style-and-animation))
- [x] Autoplay ([prop `autoplay`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#autoplay))
- [x] Loop mode ([prop `loop`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#loop))
- [x] `ScrollView`/`FlatList` carousels ([prop `useScrollView`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#behavior))
- [ ] [Callback methods](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#callbacks)
- [ ] [`ParallaxImage` component](https://github.com/archriss/react-native-snap-carousel#parallaximage-component)
- [ ] [`Pagination` component](https://github.com/archriss/react-native-snap-carousel#pagination-component)
- [ ] [Layouts and custom interpolations](https://github.com/archriss/react-native-snap-carousel#layouts-and-custom-interpolations)
