### PR TITLE
feat: Added new prop `slideComponent`

### DIFF
--- a/src/carousel/Carousel.js
+++ b/src/carousel/Carousel.js
@@ -1193,7 +1193,8 @@ export default class Carousel extends Component {
             sliderHeight,
             sliderWidth,
             slideStyle,
-            vertical
+            vertical,
+            slideComponent
         } = this.props;
 
         const animatedValue = interpolators && interpolators[index];
@@ -1203,7 +1204,7 @@ export default class Carousel extends Component {
         }
 
         const animate = this._shouldAnimateSlides();
-        const Component = animate ? Animated.View : View;
+        const Component = slideComponent ? (animate ? Animated.createAnimatedComponent(slideComponent) : slideComponent) : (animate ? Animated.View : View);
         const animatedStyle = animate ? this._getSlideInterpolatedStyle(index, animatedValue) : {};
 
         const parallaxProps = hasParallaxImages ? {


### PR DESCRIPTION
### Platforms affected

ios/android

### What does this PR do?

Allow user to customize component of slider. For example, to avoid some rendering bugs on `View`, such as `overflow: visible` not working on Android with a lower version of ReactNative, which I can use https://github.com/entria/react-native-view-overflow to replace the original View comp.

### What testing has been done on this change?

passed for my testcase, it will not affect the original logic at all.


