### PR TITLE
Fixing Warning : Calling 'getNode()' on the ref an Animated Component…

### DIFF
--- a/src/carousel/Carousel.js
+++ b/src/carousel/Carousel.js
@@ -16,8 +16,8 @@ const IS_IOS = Platform.OS === 'ios';
 
 // Native driver for scroll events
 // See: https://facebook.github.io/react-native/blog/2017/02/14/using-native-driver-for-animated.html
-const AnimatedFlatList = FlatList ? Animated.createAnimatedComponent(FlatList) : null;
-const AnimatedScrollView = Animated.createAnimatedComponent(ScrollView);
+const AnimatedFlatList = FlatList ? Animated.FlatList : null;
+const AnimatedScrollView = Animated.ScrollView;
 
 // React Native automatically handles RTL layouts; unfortunately, it's buggy with horizontal ScrollView
 // See https://github.com/facebook/react-native/issues/11960
@@ -483,7 +483,7 @@ export default class Carousel extends Component {
     _getWrappedRef () {
         // https://github.com/facebook/react-native/issues/10635
         // https://stackoverflow.com/a/48786374/8412141
-        return this._carouselRef && this._carouselRef.getNode && this._carouselRef.getNode();
+        return this._carouselRef 
     }
 
     _getScrollEnabled () {


### PR DESCRIPTION
Fixing the issue will happen when you use createAnimatedComponent for components while its already exist in animated library for example if we use it to FlatList this warning will be showing for fix it just call componenty in react native 0.62 
