### PR TITLE
Get correct carousel ref for RN 0.62.x

### DIFF
--- a/src/carousel/Carousel.js
+++ b/src/carousel/Carousel.js
@@ -481,6 +481,10 @@ export default class Carousel extends Component {
     }
 
     _getWrappedRef () {
+        if (this._carouselRef && (
+             (this._needsScrollView() && this._carouselRef.scrollTo) ||
+             (!this._needsScrollView() && this._carouselRef.scrollToOffset)
+        )) {
         // https://github.com/facebook/react-native/issues/10635
         // https://stackoverflow.com/a/48786374/8412141
         return this._carouselRef && this._carouselRef.getNode && this._carouselRef.getNode();

--- a/src/carousel/Carousel.js
+++ b/src/carousel/Carousel.js
@@ -482,9 +482,11 @@ export default class Carousel extends Component {
 
     _getWrappedRef () {
         if (this._carouselRef && (
-             (this._needsScrollView() && this._carouselRef.scrollTo) ||
-             (!this._needsScrollView() && this._carouselRef.scrollToOffset)
+            (this._needsScrollView() && this._carouselRef.scrollTo) ||
+            (!this._needsScrollView() && this._carouselRef.scrollToOffset)
         )) {
+            return this._carouselRef;
+        }
         // https://github.com/facebook/react-native/issues/10635
         // https://stackoverflow.com/a/48786374/8412141
         return this._carouselRef && this._carouselRef.getNode && this._carouselRef.getNode();


### PR DESCRIPTION
### Platforms affected
Android & iOS

### What does this PR do?
There is api change since RN 0.62.x, so calling `getNode` is no longer necessary. This PR just make sure get the correct ref for both 0.62.x and below.

### What testing has been done on this change?
- Carousel works well and no error with `snapToItem` call (Tested on RN 0.62.2 and 0.61.5 by @alessandro-bottamedi)

### Tested features checklist
<!--
IMPORTANT: Please make sure that none of these features have been broken by your changes.
It's easy to overlook something you didn't use yet.
-->
- [ ] Default setup ([example](https://github.com/archriss/react-native-snap-carousel/blob/master/example/src/index.js#L46-L87))
- [ ] Carousels with and without momentum enabled ([prop `enableMomentum`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#behavior))
- [ ] Vertical carousels ([prop `vertical`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#behavior))
- [ ] Slide alignment ([prop `activeSlideAlignment`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#style-and-animation))
- [ ] Autoplay ([prop `autoplay`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#autoplay))
- [ ] Loop mode ([prop `loop`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#loop))
- [x] `ScrollView`/`FlatList` carousels ([prop `useScrollView`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#behavior))
- [ ] [Callback methods](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#callbacks)
- [ ] [`ParallaxImage` component](https://github.com/archriss/react-native-snap-carousel#parallaximage-component)
- [ ] [`Pagination` component](https://github.com/archriss/react-native-snap-carousel#pagination-component)
- [ ] [Layouts and custom interpolations](https://github.com/archriss/react-native-snap-carousel#layouts-and-custom-interpolations)
