### PR TITLE
array map method which is listing dots is changed

### DIFF
--- a/src/pagination/Pagination.js
+++ b/src/pagination/Pagination.js
@@ -122,7 +122,7 @@ export default class Pagination extends PureComponent {
           delayPressInDot={delayPressInDot}
         />;
 
-        const dots = [...Array(dotsLength).keys()].map(i => {
+        const dots = Array.from({ length: dotsLength }, (_, i) => i).map(i => {
             const isActive = i === this._activeDotIndex;
             return React.cloneElement(
                 (isActive ? dotElement : inactiveDotElement) || DefaultDot,


### PR DESCRIPTION
Pagination dots listing array generator is not working on new android versions.

Old array generator changed with new stable working array generator with dotsLength.