### PR TITLE
Bump react-addons-shallow-compare to 15.6.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "license": "BSD-3-Clause",
     "dependencies": {
         "@types/react-addons-shallow-compare": "^0.14.22",
-        "react-addons-shallow-compare": "15.6.2"
+        "react-addons-shallow-compare": "15.6.3"
     },
     "peerDependencies": {
         "react": ">=16.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-snap-carousel",
-    "version": "4.0.0-beta.6",
+    "version": "4.0.0-beta.7",
     "description": "Swiper/carousel component for React Native with previews, multiple layouts, parallax images, performant handling of huge numbers of items, and more. Compatible with Android & iOS.",
     "main": "lib/commonjs/index",
     "module": "lib/module/index",
@@ -53,7 +53,7 @@
     },
     "devDependencies": {
         "@react-native-community/bob": "0.16.2",
-        "@types/react": "^16.9.46",
+        "@types/react": "^17.0.38",
         "@types/react-native": "^0.63.4",
         "@typescript-eslint/eslint-plugin": "3.8.0",
         "@typescript-eslint/parser": "3.8.0",
@@ -67,7 +67,7 @@
         "eslint-plugin-react": "7.20.5",
         "eslint-plugin-standard": "4.0.1",
         "react": "16.13.1",
-        "react-native": "0.63.2",
+        "react-native": "^0.67.2",
         "typescript": "3.9.7"
     },
     "eslintIgnore": [

--- a/src/carousel/Carousel.tsx
+++ b/src/carousel/Carousel.tsx
@@ -1218,7 +1218,7 @@ export class Carousel<TData> extends React.Component<
       };
   }
 
-  _getComponentStaticProps () {
+  _getComponentStaticProps (): Object {
       const { hideCarousel } = this.state;
       const {
           activeSlideAlignment,


### PR DESCRIPTION
react-native-snap-carousel@4.0.0-beta.6 requires node-fetch@^1.0.1 via a transitive dependency on isomorphic-fetch@2.2.1

The earliest fixed version of node-fetch is 2.6.7

### Platforms affected


### What does this PR do?
Update react-addons-shallow-compare dependency version from 15.6.2 to 15.6.3 to fix node-fetch vulnerability

### What testing has been done on this change?
- [ ] Integration with our project codebase (testing in progress)

### Tested features checklist
<!--
IMPORTANT: Please make sure that none of these features have been broken by your changes.
It's easy to overlook something you didn't use yet.
-->
- [ ] Default setup ([example](https://github.com/meliorence/react-native-snap-carousel/blob/master/example/src/index.js#L46-L87))
- [ ] Carousels with and without momentum enabled ([prop `enableMomentum`](https://github.com/meliorence/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#behavior))
- [ ] Vertical carousels ([prop `vertical`](https://github.com/meliorence/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#behavior))
- [ ] Slide alignment ([prop `activeSlideAlignment`](https://github.com/meliorence/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#style-and-animation))
- [ ] Autoplay ([prop `autoplay`](https://github.com/meliorence/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#autoplay))
- [ ] Loop mode ([prop `loop`](https://github.com/meliorence/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#loop))
- [ ] `ScrollView`/`FlatList` carousels ([prop `useScrollView`](https://github.com/meliorence/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#behavior))
- [ ] [Callback methods](https://github.com/meliorence/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#callbacks)
- [ ] [`ParallaxImage` component](https://github.com/meliorence/react-native-snap-carousel#parallaximage-component)
- [ ] [`Pagination` component](https://github.com/meliorence/react-native-snap-carousel#pagination-component)
- [ ] [Layouts and custom interpolations](https://github.com/meliorence/react-native-snap-carousel#layouts-and-custom-interpolations)
