### PR TITLE
removed Viewproptypes

### DIFF
--- a/src/carousel/Carousel.js
+++ b/src/carousel/Carousel.js
@@ -1,7 +1,8 @@
 import React, { Component } from 'react';
-import { Animated, Easing, FlatList, I18nManager, Platform, ScrollView, View, ViewPropTypes } from 'react-native';
+import { Animated, Easing, FlatList, I18nManager, Platform, ScrollView, View } from 'react-native';
 import PropTypes from 'prop-types';
 import shallowCompare from 'react-addons-shallow-compare';
+import ViewPropTypes from 'deprecated-react-native-prop-types'
 import {
     defaultScrollInterpolator,
     stackScrollInterpolator,

--- a/src/pagination/Pagination.js
+++ b/src/pagination/Pagination.js
@@ -1,6 +1,7 @@
 import React, { PureComponent } from 'react';
-import { I18nManager, Platform, View, ViewPropTypes } from 'react-native';
+import { I18nManager, Platform, View } from 'react-native';
 import PropTypes from 'prop-types';
+import ViewPropTypes from 'deprecated-react-native-prop-types'
 import PaginationDot from './PaginationDot';
 import styles from './Pagination.style';
 

--- a/src/pagination/PaginationDot.js
+++ b/src/pagination/PaginationDot.js
@@ -1,6 +1,7 @@
 import React, { PureComponent } from 'react';
-import { View, Animated, Easing, TouchableOpacity, ViewPropTypes } from 'react-native';
+import { View, Animated, Easing, TouchableOpacity } from 'react-native';
 import PropTypes from 'prop-types';
+import ViewPropTypes from 'deprecated-react-native-prop-types'
 import styles from './Pagination.style';
 
 export default class PaginationDot extends PureComponent {

--- a/src/parallaximage/ParallaxImage.js
+++ b/src/parallaximage/ParallaxImage.js
@@ -1,8 +1,9 @@
 // Parallax effect inspired by https://github.com/oblador/react-native-parallax/
 
 import React, { Component } from 'react';
-import { View, ViewPropTypes, Image, Animated, Easing, ActivityIndicator, findNodeHandle } from 'react-native';
+import { View, Image, Animated, Easing, ActivityIndicator, findNodeHandle } from 'react-native';
 import PropTypes from 'prop-types';
+import ViewPropTypes from 'deprecated-react-native-prop-types'
 import styles from './ParallaxImage.style';
 
 export default class ParallaxImage extends Component {


### PR DESCRIPTION
### Platforms affected
React native version 69+

### What does this PR do?
Depreciated Viewprops replaced with Depreciated viewprops

