### PR TITLE
Update Carousel.js

### DIFF
--- a/src/carousel/Carousel.js
+++ b/src/carousel/Carousel.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
-import { Animated, Easing, FlatList, I18nManager, Platform, ScrollView, View, ViewPropTypes } from 'react-native';
+import { Animated, Easing, FlatList, I18nManager, Platform, ScrollView, View} from 'react-native';
+import { ViewPropTypes} from 'deprecated-react-native-prop-types';
 import PropTypes from 'prop-types';
 import shallowCompare from 'react-addons-shallow-compare';
 import {


### PR DESCRIPTION
Import ViewPropTypes from  deprecated react-native-prop-types

### Platforms affected


### What does this PR do?


### What testing has been done on this change?


### Tested features checklist
<!--
IMPORTANT: Please make sure that none of these features have been broken by your changes.
It's easy to overlook something you didn't use yet.
-->
- [ ] Default setup ([example](https://github.com/meliorence/react-native-snap-carousel/blob/master/example/src/index.js#L46-L87))
- [ ] Carousels with and without momentum enabled ([prop `enableMomentum`](https://github.com/meliorence/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#behavior))
- [ ] Vertical carousels ([prop `vertical`](https://github.com/meliorence/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#behavior))
- [ ] Slide alignment ([prop `activeSlideAlignment`](https://github.com/meliorence/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#style-and-animation))
- [ ] Autoplay ([prop `autoplay`](https://github.com/meliorence/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#autoplay))
- [ ] Loop mode ([prop `loop`](https://github.com/meliorence/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#loop))
- [ ] `ScrollView`/`FlatList` carousels ([prop `useScrollView`](https://github.com/meliorence/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#behavior))
- [ ] [Callback methods](https://github.com/meliorence/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#callbacks)
- [ ] [`ParallaxImage` component](https://github.com/meliorence/react-native-snap-carousel#parallaximage-component)
- [ ] [`Pagination` component](https://github.com/meliorence/react-native-snap-carousel#pagination-component)
- [ ] [Layouts and custom interpolations](https://github.com/meliorence/react-native-snap-carousel#layouts-and-custom-interpolations)
