### PR TITLE
add a deprecated-react-native-prop-types

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "license": "BSD-3-Clause",
     "dependencies": {
         "prop-types": "^15.6.1",
-        "react-addons-shallow-compare": "15.6.2"
+        "react-addons-shallow-compare": "15.6.2",
+         "deprecated-react-native-prop-types": "^5.0.0"
     },
     "peerDependencies": {
         "react": ">=15.0.0",


### PR DESCRIPTION
### Platforms affected
 AOS, IOS

### What does this PR do?
 when we use this library above react native version 0.7v it show the console error like this:

ViewPropTypes will be removed from React Native, along with all other PropTypes. We recommend that you migrate away from PropTypes and switch to a type system like TypeScript. If you need to continue using ViewPropTypes, migrate to the 'deprecated-react-native-prop-types' package.

so i added deprecated-react-native-prop-types on this pacakge and added to the import.

### What testing has been done on this change?
 i actually tested on sasmsung note 20 and galaxy s9, above version ios 15.


### Tested features checklist

